### PR TITLE
GPU experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ biases2.csv
 
 .venv/
 experiments/src/bhd.scala
+
+scripts/cellar
+.cellar/

--- a/gvecxt/cyfra docs/gpu-functions.md
+++ b/gvecxt/cyfra docs/gpu-functions.md
@@ -1,0 +1,168 @@
+---
+sidebar_position: 3
+---
+
+# GPU Functions
+
+The simplest way to use the Cyfra library is with a GFunction. In essence, it is a function that takes any input you give it, runs on the GPU, and returns the output.
+
+```scala
+import io.computenode.cyfra.dsl.{*, given}
+import io.computenode.cyfra.foton.GFunction
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+@main
+def multiplyByTwo(): Unit =
+  VkCyfraRuntime.using:
+    val input = (0 until 256).map(_.toFloat).toArray
+
+    val doubleIt: GFunction[GStruct.Empty, Float32, Float32] = GFunction: x =>
+      x * 2.0f
+
+    val result: Array[Float] = doubleIt.run(input)
+
+    println(s"Output: ${result.take(10).mkString(", ")}...")
+```
+
+`doubleIt.run(input)` will simply take the provided input and run the GFunction on it. As a result, we will get an array of floats that are each a doubled entry from the input array.
+
+## Cyfra DSL
+
+When you use Cyfra, you enter a world of values that are entirely separate from standard Scala values. Float becomes `Float32`, Double becomes `Float64`, and so on. Below is a table with more examples. Those are not all the types, but this includes most important ground types (`Float32`, `Int32`, `GBoolean`, etc.). Any ground types can be then used with Vectors. Additionally any types can be composed into `GStruct`s (including other `GStruct`s).
+
+| Scala Type | Cyfra Type |
+|------------|------------|
+| `Float` | `Float32` |
+| `Double` | `Float64` |
+| `Int` | `Int32` |
+| `Int` | `UInt32` (unsigned) |
+| `Boolean` | `GBoolean` |
+| `(Float, Float)` | `Vec2[Float32]` |
+| `(Float, Float, Float, Float)` | `Vec4[Float32]` | 
+| `(Int, Int)` | `Vec2[Int32]` |
+
+The operators you use stay the same, but keep in mind - for an operation to happen on the GPU, it needs to involve a Cyfra value type.
+
+## Using Uniforms
+
+In the previous example, the GFunction only took a float array as an input. There is, however, a way to provide additional parameters to each run. This has to do with the first type parameter of `GFunction` that was set to `GStruct.Empty` in the previous example. This is the Uniform structure that can be provided for each GFunction.
+
+```scala
+case class FunctionParam(a: Float32) extends GStruct[FunctionParam]
+
+@main
+def multiplyByTwo(): Unit =
+  VkCyfraRuntime.using:
+    val input = (0 until 256).map(_.toFloat)
+
+    val doubleIt: GFunction[FunctionParam, Float32, Float32] = GFunction: 
+      (params: FunctionParam, x: Float32) =>
+        x * params.a
+
+    val params = FunctionParam(2.0f)
+    
+    val result: Array[Float] = doubleIt.run(input, params)
+
+    println(s"Output: ${result.take(10).mkString(", ")}...")
+```
+
+You can see that the lambda in GFunction takes `FunctionParam`. The GStruct case class can be any product of any Cyfra values (including other structs).
+
+## If-else becomes when-otherwise
+
+Because in Cyfra we live in a different (GPU) world, it is required to use alternative control expressions. The most basic one is the `when`(-`elseWhen`-)`otherwise`:
+```scala
+val multiplyIt: GFunction[FunctionParam, Float32, Float32] = GFunction: 
+  (params: FunctionParam, x: Float32) =>
+    when(x < 100f):
+      x * params.a
+    .elseWhen(x < 200f):
+      x * params.a * 2f
+    .otherwise:
+      x * params.a * 4f
+```
+
+## GSeqs
+
+To iterate and express collections, Cyfra offers a `GSeq` type. It corresponds to a `LazyList` from Scala - a lazily evaluated sequence that can be transformed and consumed with familiar functional operations.
+
+### Creating a GSeq
+
+Use `GSeq.gen` to create a sequence by providing an initial value and a function that produces the next element:
+
+```scala
+// Create from a known list of elements
+val colors = GSeq.of(List(red, green, blue))
+
+// Generate integers: 0, 1, 2, 3, ...
+val integers = GSeq.gen[Int32](0, n => n + 1)
+
+// Generate Fibonacci-like pairs using Vec2: (0,1), (1,1), (1,2), (2,3), ...
+val fibonacci = GSeq.gen[Vec2[Float32]]((0.0f, 1.0f), pair => (pair.y, pair.x + pair.y))
+
+// Mandelbrot iteration: z = z² + c
+val mandelbrot = GSeq.gen(
+  vec2(0.0f, 0.0f), 
+  z => vec2(z.x * z.x - z.y * z.y + cx, 2.0f * z.x * z.y + cy)
+)
+```
+
+You must always call `.limit(n)` before consuming a GSeq to set a maximum iteration count (infinite sequences are not supported on GPU).
+
+### Map, filter, takeWhile
+
+Transform and filter sequences with familiar operations:
+
+```scala
+// Map: transform each element
+val doubled = GSeq.gen[Int32](0, _ + 1).limit(100).map(_ * 2)
+
+// Filter: keep only matching elements
+val evens = GSeq.gen[Int32](0, _ + 1).limit(100).filter(n => n.mod(2) === 0)
+
+// TakeWhile: stop when condition becomes false
+val underTen = GSeq.gen[Int32](0, _ + 1).limit(100).takeWhile(_ < 10)
+```
+
+These can be chained together:
+
+```scala
+// Julia set iteration: iterate until escape or limit
+val iterations = GSeq
+  .gen(uv, v => ((v.x * v.x) - (v.y * v.y), 2.0f * v.x * v.y) + const)
+  .limit(1000)
+  .map(length)           // Transform to magnitude
+  .takeWhile(_ < 2.0f)   // Stop when magnitude exceeds 2
+```
+
+### Fold, count, lastOr
+
+Terminal operations consume the sequence and produce a result:
+
+```scala
+// Count: number of elements that passed through
+val iterationCount: Int32 = GSeq
+  .gen(vec2(0f, 0f), z => vec2(z.x*z.x - z.y*z.y + cx, 2f*z.x*z.y + cy))
+  .limit(256)
+  .takeWhile(z => z.x*z.x + z.y*z.y < 4.0f)
+  .count
+
+// Fold: reduce with accumulator
+val sum: Int32 = GSeq.gen[Int32](1, _ + 1).limit(10).fold(0, _ + _)
+
+// LastOr: get final element (or default if empty)
+val finalValue: Int32 = GSeq.gen[Int32](0, _ + 1).limit(10).lastOr(0)
+```
+
+**Every GSeq must have a hard `limit` of maximum elements it can hold**
+
+
+## Example usage
+
+GFunction may be a simple construct, but it is enough to accelerate many applications. An example is a raytracer that would otherwise take a very long time to run on a CPU. Here is the implementation of a raytracer with Cyfra:
+
+![Animated Raytracing](https://github.com/user-attachments/assets/3eac9f7f-72df-4a5d-b768-9117d651c78d)
+
+Source:
+ - [ImageRtRenderer.scala](https://github.com/ComputeNode/cyfra/blob/cab6b4cae3a3402a3de43272bc7cb50acf5ec67b/cyfra-foton/src/main/scala/io/computenode/cyfra/foton/rt/ImageRtRenderer.scala)
+ - [RtRenderer.scala](https://github.com/ComputeNode/cyfra/blob/cab6b4cae3a3402a3de43272bc7cb50acf5ec67b/cyfra-foton/src/main/scala/io/computenode/cyfra/foton/rt/RtRenderer.scala)

--- a/gvecxt/cyfra docs/gpu-pipelines.md
+++ b/gvecxt/cyfra docs/gpu-pipelines.md
@@ -1,0 +1,175 @@
+---
+sidebar_position: 5
+---
+
+# GPU Pipelines with GExecution
+
+When you need to run multiple GPU programs in sequence, sharing data between them, `GExecution` provides a composable way to build GPU pipelines. The big benefit is that those pipelines, even highly complex ones, are materialized as one on the GPU and will synchronize and pass data without any operations on the CPU side. This greatly improves performance of computations.
+
+## What is GExecution?
+
+`GExecution` represents a sequence of GPU operations that can be composed together. It's a monadic abstraction that allows you to:
+
+- Chain multiple `GProgram`s together
+- Share buffers between pipeline stages
+- Transform parameters and layouts between programs
+
+Every `GProgram` is also a `GExecution`, making them directly composable.
+
+## Building a Simple Pipeline
+
+Let's build a pipeline that doubles values and then adds a constant:
+
+```scala
+import io.computenode.cyfra.core.{GBufferRegion, GExecution, GProgram}
+import io.computenode.cyfra.core.GProgram.StaticDispatch
+import io.computenode.cyfra.core.layout.Layout
+import io.computenode.cyfra.dsl.{*, given}
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+// Step 1: Define individual programs
+
+case class DoubleLayout(input: GBuffer[Float32], output: GBuffer[Float32]) derives Layout
+
+val doubleProgram: GProgram[Int, DoubleLayout] = GProgram[Int, DoubleLayout](
+  layout = size => DoubleLayout(
+    input = GBuffer[Float32](size), 
+    output = GBuffer[Float32](size)
+  ),
+  dispatch = (_, size) => StaticDispatch(((size + 255) / 256, 1, 1)),
+  workgroupSize = (256, 1, 1),
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = GIO.read(layout.input, idx)
+    GIO.write(layout.output, idx, value * 2.0f)
+
+case class SumParams(value: Float32) extends GStruct[SumParams]
+case class SumLayout(
+  input: GBuffer[Float32], 
+  output: GBuffer[Float32], 
+  params: GUniform[AddParams]
+) derives Layout
+
+val sumProgram: GProgram[Int, SumLayout] = GProgram[Int, SumLayout](
+  layout = size => SumLayout(
+    input = GBuffer[Float32](size), 
+    output = GBuffer[Float32](size), 
+    params = GUniform[SumParams]()
+  ),
+  dispatch = (_, size) => StaticDispatch(((size + 255) / 256, 1, 1)),
+  workgroupSize = (256, 1, 1),
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = GIO.read(layout.input, idx)
+    val addValue = layout.params.read.value
+    GIO.write(layout.output, idx, value + addValue)
+```
+
+## Composing Programs with addProgram
+
+The key to building pipelines is the `addProgram` method. It takes:
+
+1. A program to add to the execution
+2. A function to map pipeline parameters to program parameters
+3. A function to map the pipeline layout to the program's layout
+
+```scala
+// Step 2: Define the combined pipeline layout
+case class PipelineLayout(
+  input: GBuffer[Float32],
+  doubled: GBuffer[Float32],   // Intermediate buffer
+  output: GBuffer[Float32],
+  sumParams: GUniform[SumParams]
+) derives Layout
+
+// Step 3: Compose the pipeline
+val doubleAndAddPipeline: GExecution[Int, PipelineLayout, PipelineLayout] =
+  GExecution[Int, PipelineLayout]()
+    .addProgram(doubleProgram)(
+      size => size,  // Map params: pipeline size -> program size
+      layout => DoubleLayout(layout.input, layout.doubled)  // Map layout
+    )
+    .addProgram(sumProgram)(
+      size => size,
+      layout => SumLayout(layout.doubled, layout.output, layout.sumParams)
+    )
+```
+
+Notice how the `doubled` buffer connects the two programs - the first program writes to it, and the second reads from it.
+
+**Pipelines can be made from any number of GPrograms that form a directed acyclic graph.**
+
+## Running the Pipeline
+
+Execute the pipeline using `GBufferRegion`:
+
+```scala
+@main
+def runDoubleAndSumPipeline(): Unit = VkCyfraRuntime.using:
+  val size = 256
+  val inputData = (0 until size).map(_.toFloat).toArray
+  val results = Array.ofDim[Float](size)
+
+  val region = GBufferRegion
+    .allocate[PipelineLayout]
+    .map: layout =>
+      doubleAndAddPipeline.execute(size, layout)
+
+  region.runUnsafe(
+    init = PipelineLayout(
+      input = GBuffer(inputData),
+      doubled = GBuffer[Float32](size),
+      output = GBuffer[Float32](size),
+      sumParams = GUniform(SumParams(10.0f)),
+    ),
+    onDone = layout => layout.output.readArray(results),
+  )
+```
+
+## GExecution Operations
+
+`GExecution` provides several composition methods:
+
+### addProgram
+
+Add another program to the pipeline, mapping parameters and layout:
+
+```scala
+execution.addProgram(program)(
+  mapParams = pipelineParams => programParams,
+  mapLayout = pipelineLayout => programLayout
+)
+```
+
+### map
+
+Transform the result layout:
+
+```scala
+execution.map(resultLayout => newResultLayout)
+```
+
+### flatMap
+
+Sequence executions where the second depends on the first's result:
+
+```scala
+execution.flatMap: resultLayout =>
+  anotherExecution
+```
+
+## Example: Case-study on fs2 filtering
+
+A great read for understanding pipelines is a report from our contributor `spamegg`. It describes a process of implementing a [parallel prefix sum](https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda) based filtering approach. We highly recommend reading it: [GSoC 2025: fs2 filtering through Cyfra](https://spamegg1.github.io/gsoc-2025/#fs2-filtering-through-cyfra).
+
+This article also tackles the topic of adapting GPrograms of mismatched Layouts and Parameters with `contramap` and `contramapParams`. They make it possible to connect any kinds of unrelated GPrograms into one pipeline.
+
+## Example: Navier-Stokes Fluid Simulation
+
+The `cyfra-fluids` module implements a full 3D Navier-Stokes fluid solver using GExecution pipelines. Each simulation step chains multiple GPU programs: forces, advection, diffusion, pressure projection, and boundary conditions. The GPipeline in this example is built from over 100 GPrograms.
+
+![Fluid Simulation](/img/full_fluid_8s.gif)
+
+[View the implementation](https://github.com/ComputeNode/cyfra/tree/cab6b4cae3a3402a3de43272bc7cb50acf5ec67b/cyfra-fluids/src/main/scala/io/computenode/cyfra/fluids)

--- a/gvecxt/cyfra docs/gpu-programs.md
+++ b/gvecxt/cyfra docs/gpu-programs.md
@@ -1,0 +1,370 @@
+---
+sidebar_position: 4
+---
+
+# GPU Programs and Memory
+
+While `GFunction` provides a simple interface for running computations on GPU, `GProgram` and `GBufferRegion` offer more control over GPU memory management and program execution. These are the building blocks for more complex GPU workloads.
+
+## GProgram
+
+A `GProgram` represents a single GPU compute shader. It defines:
+
+- **Layout** - What buffers and uniforms the program needs
+- **Dispatch** - How many work groups to launch
+- **Body** - The actual computation performed by each GPU thread
+
+```scala
+import io.computenode.cyfra.core.GProgram
+import io.computenode.cyfra.core.layout.Layout
+import io.computenode.cyfra.dsl.{*, given}
+
+case class DoubleLayout(
+  input: GBuffer[Float32], 
+  output: GBuffer[Float32]
+) derives Layout
+
+val doubleProgram: GProgram[Int, DoubleLayout] = GProgram.static[Int, DoubleLayout](
+  layout = size => DoubleLayout(
+    input = GBuffer[Float32](size), 
+    output = GBuffer[Float32](size)
+  ),
+  dispatchSize = size => size,
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = layout.input.read(idx)
+    layout.output.write(idx, value * 2.0f)
+```
+
+There are many elements in that snippet that may seem unfamiliar at the moment, but they will be addressed in this article:
+ - What are the layout and dispatch?
+ - What is GIO and its members like `invocationId`, `when`, `write`, `read`?
+ - How to execute a GProgram, and how does it execute?
+
+### Layout
+
+The layout is a case class that contains all the buffers (`GBuffer`) and uniforms (`GUniform`) your program needs. It must derive `Layout` for Cyfra to understand its structure.
+
+- **GBuffer[T]** - A GPU buffer that stores an array of values of type `T`
+- **GUniform[T]** - A uniform value (constant for all invocations) of type `T` (must extend `GStruct`)
+
+Layout is a product of GBuffers and GUniforms and it does not enforce any structure. Any of them can be an input, output, or some intermediate step in computation. 
+
+### Dispatch and Execution Model
+
+GPU programs execute in parallel across many threads. The execution is organized in a hierarchy:
+
+1. **Invocations (threads)** - Individual parallel executions of your program body
+2. **Workgroups** - Groups of invocations that can share memory and synchronize
+3. **Dispatch** - The total number of workgroups to launch
+
+When you dispatch a program, the GPU runs:
+```
+Total invocations = workgroups.x × workgroups.y × workgroups.z × workgroupSize.x × workgroupSize.y × workgroupSize.z
+```
+
+#### GProgram.static
+
+The simplest way to create a program. You specify how many elements to process, and Cyfra calculates the workgroup count automatically:
+
+```scala
+val program = GProgram.static[Int, MyLayout](
+  layout = size => MyLayout(...),
+  dispatchSize = size => size
+): layout =>
+  // body
+```
+
+For example, with `dispatchSize = 256` and default `workgroupSize = (128, 1, 1)`:
+- Cyfra computes `workgroups = ((256 + 127) / 128, 1, 1) = (2, 1, 1)`
+- Total invocations = 2 × 128 = 256 threads running in parallel
+
+Each thread gets a unique `GIO.invocationId` from 0 to 255.
+
+#### GProgram.apply
+
+For full control over dispatch, use the explicit API:
+
+```scala
+import io.computenode.cyfra.core.GProgram.{StaticDispatch, DynamicDispatch}
+
+val program = GProgram[Int, MyLayout](
+  layout = size => MyLayout(...),
+  dispatch = (layout, size) => StaticDispatch(((size + 255) / 256, 1, 1)),
+  workgroupSize = (256, 1, 1),
+): layout =>
+  // body
+```
+
+Dispatch options:
+- **StaticDispatch(x, y, z)** - Fixed number of workgroups, known at compile time
+- **DynamicDispatch(buffer, offset)** - Workgroup count read from a GPU buffer at runtime (for indirect dispatch)
+
+### GIO - Mutable operations 
+
+`GIO` represents GPU operations. Because it's a monad, you must compose operations using `for`/`yield` or `flatMap`/`map`.
+
+```scala
+layout =>
+  val idx = GIO.invocationId
+  val in = layout.input.read(idx)
+  for
+    _ <- layout.outputA.write(idx, value) // Buffer writes return GIOs
+    _ <- layout.outputB.write(idx, value * 2.0f)
+  yield ()
+```
+
+## GBufferRegion
+
+Now that we understand `GProgram`, we need a way to execute it. `GBufferRegion` manages GPU memory allocation and provides a structured way to:
+
+1. Allocate GPU buffers
+2. Run programs that use those buffers
+3. Read results back to CPU
+
+`DoubleProgram` and `DoubleLayout` are the custom definitions that were shown in the previous section. Those define your custom program.
+
+```scala
+import io.computenode.cyfra.core.GBufferRegion
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+@main
+def run = VkCyfraRuntime.using:
+  val size = 256
+  val inputData = (0 until size).map(_.toFloat).toArray
+  val results = Array.ofDim[Float](size)
+
+  val region = GBufferRegion
+    .allocate[DoubleLayout]
+    .map: layout =>
+      doubleProgram.execute(size, layout)
+
+  region.runUnsafe(
+    // Init values on start of the pipeline
+    init = DoubleLayout(
+      input = GBuffer(inputData),
+      output = GBuffer[Float32](size),
+    ),
+    // Read results when done
+    onDone = layout => layout.output.readArray(results),
+  )
+
+  println(s"Results: ${results.take(5).mkString(", ")}...")
+  // Results: 0.0, 2.0, 4.0, 6.0, 8.0...
+```
+
+### How GBufferRegion Works
+
+1. **allocate[Layout]** - Declares what buffers need to be allocated
+2. **map** - Chains operations (like executing programs) on the allocated buffers
+3. **runUnsafe** - Actually allocates GPU memory, runs the computation, and cleans up
+
+The `init` parameter provides initial data for buffers:
+- `GBuffer(array)` - Initialize a buffer with data from a Scala array
+- `GBuffer[T](size)` - Allocate an empty buffer of the given size
+- `GUniform(value)` - Initialize a uniform with a struct value
+
+The `onDone` callback lets you read results:
+- `buffer.readArray(targetArray)` - Copy GPU buffer contents to a Scala array
+
+## Complete Example: Parameterized Program
+
+Here's a complete example with a uniform parameter:
+
+```scala
+import io.computenode.cyfra.core.{GBufferRegion, GProgram}
+import io.computenode.cyfra.core.layout.Layout
+import io.computenode.cyfra.dsl.{*, given}
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+// Define a struct for uniform parameters
+case class MulParams(factor: Float32) extends GStruct[MulParams]
+
+// Define the program layout
+case class MulLayout(
+  input: GBuffer[Float32], 
+  output: GBuffer[Float32], 
+  params: GUniform[MulParams]
+) derives Layout
+
+// Create the program
+val mulProgram: GProgram[Int, MulLayout] = GProgram.static[Int, MulLayout](
+  layout = size => MulLayout(
+    input = GBuffer[Float32](size), 
+    output = GBuffer[Float32](size), 
+    params = GUniform[MulParams]()
+  ),
+  dispatchSize = size => size,
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = layout.input.read(idx)
+    val factor = layout.params.read.factor
+    layout.output.write(idx, value * factor)
+
+@main
+def runMultiply(): Unit = VkCyfraRuntime.using:
+  val size = 256
+  val inputData = (0 until size).map(_.toFloat).toArray
+  val results = Array.ofDim[Float](size)
+
+  val region = GBufferRegion
+    .allocate[MulLayout]
+    .map: layout =>
+      mulProgram.execute(size, layout)
+
+  region.runUnsafe(
+    init = MulLayout(
+      input = GBuffer(inputData),
+      output = GBuffer[Float32](size),
+      params = GUniform(MulParams(3.0f)), // Multiply by 3
+    ),
+    onDone = layout => layout.output.readArray(results),
+  )
+```
+
+In this example you can also see how `GUniform` can be used to pass a single value to the program (contrary to GBuffer that represents an array of values).
+
+## Running Multiple Programs
+
+You can run multiple programs within a single `GBufferRegion.map` block. The key insight is that `.execute` returns the Layout, so you can use the output buffers from one program as input to the next.
+
+```scala
+import io.computenode.cyfra.core.{GBufferRegion, GProgram}
+import io.computenode.cyfra.core.layout.Layout
+import io.computenode.cyfra.dsl.{*, given}
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+// Program 1: Double the input
+case class DoubleLayout(input: GBuffer[Float32], output: GBuffer[Float32]) derives Layout
+
+val doubleProgram = GProgram.static[Int, DoubleLayout](
+  layout = size => DoubleLayout(GBuffer[Float32](size), GBuffer[Float32](size)),
+  dispatchSize = size => size
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = layout.input.read(idx)
+    layout.output.write(idx, value * 2.0f)
+  yield ()
+
+// Program 2: Add a constant
+case class AddParams(addend: Float32) extends GStruct[AddParams]
+case class AddLayout(input: GBuffer[Float32], output: GBuffer[Float32], params: GUniform[AddParams]) derives Layout
+
+val addProgram = GProgram.static[Int, AddLayout](
+  layout = size => AddLayout(GBuffer[Float32](size), GBuffer[Float32](size), GUniform[AddParams]()),
+  dispatchSize = size => size
+): layout =>
+  val idx = GIO.invocationId
+  GIO.when(idx < 256):
+    val value = layout.input.read(idx)
+    val addend = layout.params.read.addend
+    layout.output.write(idx, value + addend)
+  yield ()
+
+// Combined layout with intermediate buffer
+case class PipelineLayout(
+  input: GBuffer[Float32],
+  intermediate: GBuffer[Float32],  // Output of program 1, input of program 2
+  output: GBuffer[Float32],
+  addParams: GUniform[AddParams]
+) derives Layout
+
+@main
+def runPipeline(): Unit = VkCyfraRuntime.using:
+  val size = 256
+  val inputData = (0 until size).map(_.toFloat).toArray
+  val results = Array.ofDim[Float](size)
+
+  val region = GBufferRegion
+    .allocate[PipelineLayout]
+    .map: layout =>
+      // Program 1: input -> intermediate (doubles values)
+      val afterDouble = doubleProgram.execute(size, DoubleLayout(layout.input, layout.intermediate))
+      
+      // Program 2: use intermediate from afterDouble as input, write to output
+      addProgram.execute(size, AddLayout(afterDouble.output, layout.output, layout.addParams))
+      
+      // Return the original layout
+      layout
+
+  region.runUnsafe(
+    init = PipelineLayout(
+      input = GBuffer(inputData),
+      intermediate = GBuffer[Float32](size),
+      output = GBuffer[Float32](size),
+      addParams = GUniform(AddParams(10.0f)),
+    ),
+    onDone = layout => layout.output.readArray(results),
+  )
+```
+
+In this example, you can see that there is an `intermediate` buffer introduced, that is neither an input or an output of our GPU pipeline. It just is used to transfer data between programs.
+
+## Using java.nio's ByteBuffers
+
+While Scala arrays are convenient for small datasets, `ByteBuffer` provides a more efficient alternative for large data or when integrating with native libraries.
+
+### Initializing GBuffer from ByteBuffer
+
+Use `GBuffer[T](byteBuffer)` to create a buffer from existing data:
+
+```scala
+import java.nio.{ByteBuffer, ByteOrder}
+
+val data = (0 until 1024).toArray
+val byteBuffer = ByteBuffer.allocateDirect(data.length * 4).order(ByteOrder.nativeOrder())
+byteBuffer.asIntBuffer().put(data)
+byteBuffer.flip()
+
+region.runUnsafe(
+  init = MyLayout(
+    input = GBuffer[Int32](byteBuffer),  // Initialize from ByteBuffer
+    output = GBuffer[Int32](1024),
+  ),
+  onDone = layout => ...
+)
+```
+
+### Reading Results to ByteBuffer
+
+Use `buffer.read(byteBuffer)` to copy GPU data directly into a ByteBuffer:
+
+```scala
+import java.nio.{ByteBuffer, ByteOrder}
+
+val resultBuffer = ByteBuffer.allocateDirect(1024 * 4).order(ByteOrder.nativeOrder())
+
+region.runUnsafe(
+  init = MyLayout(...),
+  onDone = layout => layout.output.read(resultBuffer),  // Read into ByteBuffer
+)
+
+// Access results
+val intView = resultBuffer.asIntBuffer()
+val firstValue = intView.get(0)
+```
+
+### Writing to GPU from ByteBuffer
+
+For dynamic updates, use `buffer.write(byteBuffer)`:
+
+```scala
+val updateBuffer = ByteBuffer.allocateDirect(1024 * 4).order(ByteOrder.nativeOrder())
+updateBuffer.asFloatBuffer().put(newData)
+updateBuffer.flip()
+
+// Inside onDone or map block:
+layout.someBuffer.write(updateBuffer)
+```
+
+### When to Use ByteBuffers
+
+- **Large datasets** - Avoids array copy overhead
+- **Native interop** - Works with LWJGL, JNI, or memory-mapped files
+- **Streaming data** - Reuse buffers across multiple runs
+- **Custom layouts** - Direct control over memory layout and byte ordering
+
+For more complex compositions with better type safety and reusability, see [GPU Pipelines](./gpu-pipelines.md).

--- a/gvecxt/cyfra docs/there-is-more.md
+++ b/gvecxt/cyfra docs/there-is-more.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 6
+---
+
+# There is more
+
+Just like the Cyfra library, this documentation is a work in progress. There are many components of Cyfra that are already deep in development that are not yet documented. For the curious ones, we recommend looking at various examples of those components in our codebase:
+
+## FS2 Integration
+
+Stream processing with GPU acceleration using fs2 pipes:
+- [GPipe](https://github.com/ComputeNode/cyfra/blob/main/cyfra-fs2/src/main/scala/io/computenode/cyfra/fs2interop/GPipe.scala) - GPU-accelerated fs2 pipes for map, filter, and batch operations
+- [GCluster](https://github.com/ComputeNode/cyfra/blob/main/cyfra-fs2/src/main/scala/io/computenode/cyfra/fs2interop/GCluster.scala) - Fuzzy C-Means clustering on GPU streams
+
+## Foton Animation Library
+
+Create GPU-accelerated animations and ray-traced scenes:
+- [AnimatedFunction](https://github.com/ComputeNode/cyfra/blob/main/cyfra-foton/src/main/scala/io/computenode/cyfra/foton/animation/AnimatedFunction.scala) - Animate mathematical functions over time
+- [AnimationRtRenderer](https://github.com/ComputeNode/cyfra/blob/main/cyfra-foton/src/main/scala/io/computenode/cyfra/foton/rt/animation/AnimationRtRenderer.scala) - Animated ray-traced scene renderer
+- [RtRenderer](https://github.com/ComputeNode/cyfra/blob/main/cyfra-foton/src/main/scala/io/computenode/cyfra/foton/rt/RtRenderer.scala) - Core ray tracing implementation
+
+## SPIR-V Debugging Tools
+
+
+:::note
+This requires an installed Vulkan SDK.
+:::
+
+
+Tools for working with SPIR-V bytecode. Use `SpirvToolsRunner` to process shaders with multiple tools:
+
+```scala
+import io.computenode.cyfra.spirvtools.*
+import io.computenode.cyfra.spirvtools.SpirvTool.{ToFile, ToLogger}
+
+// Configure which tools to run
+val runner = SpirvToolsRunner(
+  validator = SpirvValidator.Enable(throwOnFail = true),
+  optimizer = SpirvOptimizer.Enable(settings = Seq(Param("-O"))),
+  disassembler = SpirvDisassembler.Enable(toolOutput = ToLogger),
+  crossCompilation = SpirvCross.Enable(toolOutput = ToFile("output", "shader.glsl")),
+)
+
+// Process shader bytecode
+val optimizedCode = runner.processShaderCodeWithSpirvTools(shaderCode)
+```
+
+Or use individual tools directly:
+
+```scala
+// Validate SPIR-V bytecode
+SpirvValidator.validateSpirv(shaderCode, SpirvValidator.Enable(throwOnFail = true))
+
+// Disassemble to readable assembly
+val assembly: Option[String] = SpirvDisassembler.disassembleSpirv(
+  shaderCode, 
+  SpirvDisassembler.Enable(toolOutput = ToLogger)
+)
+
+// Optimize for performance
+val optimized: Option[ByteBuffer] = SpirvOptimizer.optimizeSpirv(
+  shaderCode,
+  SpirvOptimizer.Enable(settings = Seq(Param("-O")))
+)
+
+// Cross-compile to GLSL
+val glsl: Option[String] = SpirvCross.crossCompileSpirv(
+  shaderCode,
+  SpirvCross.Enable(toolOutput = ToLogger)
+)
+```
+

--- a/gvecxt/package.mill
+++ b/gvecxt/package.mill
@@ -1,0 +1,25 @@
+package build.gvecxt
+
+import mill.*, scalalib.*
+
+object `package` extends ScalaModule:
+  def scalaVersion = build.vecxt.jvm.scalaVersion
+
+  override def moduleDeps = Seq(build.vecxt.jvm)
+
+  override def forkArgs = super.forkArgs() ++ build.vecIncubatorFlag ++ Seq("-Xmx12g")
+
+  override def mvnDeps = super.mvnDeps() ++ Seq(
+    mvn"io.computenode::cyfra-foton:0.1.0-RC1",
+    mvn"org.lwjgl:lwjgl:3.4.0;classifier=natives-macos-arm64",
+    mvn"org.lwjgl:lwjgl-vulkan:3.4.0;classifier=natives-macos-arm64",
+    mvn"org.lwjgl:lwjgl-vma:3.4.0;classifier=natives-macos-arm64"
+  )
+
+  object test extends ScalaTests, TestModule.Munit:
+    override def forkArgs = super.forkArgs() ++ build.vecIncubatorFlag
+    override def mvnDeps = super.mvnDeps() ++ Seq(
+      mvn"org.scalameta::munit::${build.V.munitVersion}"
+    )
+  end test
+end `package`

--- a/gvecxt/src/GArray.scala
+++ b/gvecxt/src/GArray.scala
@@ -1,0 +1,274 @@
+package vecxt.gpu
+
+import io.computenode.cyfra.core.{CyfraRuntime, GBufferRegion}
+import io.computenode.cyfra.core.GProgram
+import io.computenode.cyfra.core.layout.Layout
+import io.computenode.cyfra.dsl.{*, given}
+import io.computenode.cyfra.dsl.binding.{GBuffer, GUniform}
+import io.computenode.cyfra.dsl.gio.GIO
+import io.computenode.cyfra.dsl.library.Functions as F
+import io.computenode.cyfra.dsl.struct.{GStruct, GStructSchema}
+import io.computenode.cyfra.foton.GFunction
+
+// ── AST node types ─────────────────────────────────────────
+
+enum UnaryFn:
+  case Neg, Abs, Exp, Sqrt, Sin, Cos, Tan, Asin, Acos, Atan, Log
+
+enum ScalarFn:
+  case Add, Sub, Mul, Div, Pow
+
+enum BinaryFn:
+  case Add, Sub, Mul, Div
+
+// ── Expression tree ────────────────────────────────────────
+
+sealed trait GExpr:
+
+  // ── Unary elementwise (builds AST, no GPU work) ────────
+  def neg: GExpr = GUnaryOp(this, UnaryFn.Neg)
+  def abs: GExpr = GUnaryOp(this, UnaryFn.Abs)
+  def exp: GExpr = GUnaryOp(this, UnaryFn.Exp)
+  def sqrt: GExpr = GUnaryOp(this, UnaryFn.Sqrt)
+  def sin: GExpr = GUnaryOp(this, UnaryFn.Sin)
+  def cos: GExpr = GUnaryOp(this, UnaryFn.Cos)
+  def tan: GExpr = GUnaryOp(this, UnaryFn.Tan)
+  def asin: GExpr = GUnaryOp(this, UnaryFn.Asin)
+  def acos: GExpr = GUnaryOp(this, UnaryFn.Acos)
+  def atan: GExpr = GUnaryOp(this, UnaryFn.Atan)
+  def log: GExpr = GUnaryOp(this, UnaryFn.Log)
+
+  // ── Scalar arithmetic (builds AST) ─────────────────────
+  def +(d: Float): GExpr = GScalarOp(this, d, ScalarFn.Add)
+  def -(d: Float): GExpr = GScalarOp(this, d, ScalarFn.Sub)
+  def *(d: Float): GExpr = GScalarOp(this, d, ScalarFn.Mul)
+  def /(d: Float): GExpr = GScalarOp(this, d, ScalarFn.Div)
+  def **(power: Float): GExpr = GScalarOp(this, power, ScalarFn.Pow)
+
+  def fma(multiply: Float, add: Float): GExpr =
+    GScalarOp(GScalarOp(this, multiply, ScalarFn.Mul), add, ScalarFn.Add)
+
+  def clamp(floor: Float, ceil: Float): GExpr =
+    GClampOp(this, floor, ceil)
+
+  // ── Elementwise binary (builds AST) ────────────────────
+  def +(other: GExpr): GExpr = GBinaryOp(this, other, BinaryFn.Add)
+  def -(other: GExpr): GExpr = GBinaryOp(this, other, BinaryFn.Sub)
+  def *(other: GExpr): GExpr = GBinaryOp(this, other, BinaryFn.Mul)
+  def /(other: GExpr): GExpr = GBinaryOp(this, other, BinaryFn.Div)
+
+  // ── Materialize: compile AST → GPU dispatch → result ───
+  def run(using CyfraRuntime): Array[Float] = GExprCompiler.run(this)
+
+  /** Phase 1: Walk the AST and compute the dimension at each node.
+    * All ops are elementwise, so propagation is trivial.
+    * Catches dimension mismatches eagerly — no GPU work, no data movement.
+    */
+  def validateDimensions: Int = GExprCompiler.shapeAnalysis(this)
+end GExpr
+
+case class GLeaf(data: Array[Float]) extends GExpr
+case class GUnaryOp(input: GExpr, fn: UnaryFn) extends GExpr
+case class GScalarOp(input: GExpr, scalar: Float, fn: ScalarFn) extends GExpr
+case class GClampOp(input: GExpr, floor: Float, ceil: Float) extends GExpr
+case class GBinaryOp(left: GExpr, right: GExpr, fn: BinaryFn) extends GExpr
+
+// ── Compiler: GExpr AST → Cyfra GFunction → GPU ───────────
+
+/** Set to true to log CPU↔GPU transfer events to stderr. */
+var logGExprTransfers: Boolean = false
+
+private[gpu] object GExprCompiler:
+
+  private def transferLog(msg: => String): Unit =
+    if logGExprTransfers then System.err.println(s"[GExpr] $msg")
+
+  /** Phase 1: Walk the AST and compute the dimension at each node.
+    * All ops are elementwise, so propagation is trivial.
+    * Catches dimension mismatches eagerly — no GPU work, no data movement.
+    */
+  def shapeAnalysis(expr: GExpr): Int =
+    expr match
+      case GLeaf(data)                 => data.length
+      case GUnaryOp(input, _)          => shapeAnalysis(input)
+      case GScalarOp(input, _, _)      => shapeAnalysis(input)
+      case GClampOp(input, _, _)       => shapeAnalysis(input)
+      case GBinaryOp(left, right, _)   =>
+        val ld = shapeAnalysis(left)
+        val rd = shapeAnalysis(right)
+        if ld != rd then
+          throw new IllegalArgumentException(
+            s"GExpr dimension mismatch: left has $ld elements, right has $rd"
+          )
+        ld
+
+  def run(expr: GExpr)(using CyfraRuntime): Array[Float] =
+    shapeAnalysis(expr) // Phase 1: validate dimensions before any GPU work
+    val leaves = collectLeaves(expr)
+    transferLog(s"run: ${leaves.size} leaf(s), expr=${exprLabel(expr)}")
+    leaves match
+      case single :: Nil => runSingleInput(expr, single)
+      case _             => runFused(expr, leaves)
+
+  private def collectLeaves(expr: GExpr): List[GLeaf] =
+    expr match
+      case l: GLeaf              => List(l)
+      case GUnaryOp(input, _)    => collectLeaves(input)
+      case GScalarOp(input, _, _) => collectLeaves(input)
+      case GClampOp(input, _, _) => collectLeaves(input)
+      case GBinaryOp(left, right, _) =>
+        val ll = collectLeaves(left)
+        val rl = collectLeaves(right)
+        (ll ++ rl).distinctBy(_.data.asInstanceOf[AnyRef])
+
+  // ── Single-input path: fuse entire chain into one GFunction ──
+
+  private def runSingleInput(expr: GExpr, leaf: GLeaf)(using CyfraRuntime): Array[Float] =
+    transferLog(s"  CPU→GPU upload ${leaf.data.length} floats (runSingleInput)")
+    val gf: GFunction[GStruct.Empty, Float32, Float32] = GFunction { (x: Float32) =>
+      compileSingle(expr, leaf, x)
+    }
+    val result: Array[Float] = gf.run(leaf.data)
+    transferLog(s"  GPU→CPU download ${result.length} floats (runSingleInput)")
+    result
+
+  private def compileSingle(expr: GExpr, leaf: GLeaf, x: Float32)(using Source): Float32 =
+    expr match
+      case l: GLeaf =>
+        assert(l.data.asInstanceOf[AnyRef] eq leaf.data.asInstanceOf[AnyRef])
+        x
+      case GUnaryOp(input, fn) =>
+        val inner = compileSingle(input, leaf, x)
+        applyUnary(fn, inner)
+      case GScalarOp(input, s, fn) =>
+        val inner = compileSingle(input, leaf, x)
+        applyScalar(fn, inner, s)
+      case GClampOp(input, floor, ceil) =>
+        val inner = compileSingle(input, leaf, x)
+        F.clamp(inner, floor, ceil)
+      case GBinaryOp(left, right, fn) =>
+        val l = compileSingle(left, leaf, x)
+        val r = compileSingle(right, leaf, x)
+        applyBinary(fn, l, r)
+
+  private def applyUnary(fn: UnaryFn, v: Float32)(using Source): Float32 =
+    fn match
+      case UnaryFn.Neg  => -v
+      case UnaryFn.Abs  => F.abs(v)
+      case UnaryFn.Exp  => F.exp(v)
+      case UnaryFn.Sqrt => F.sqrt(v)
+      case UnaryFn.Sin  => F.sin(v)
+      case UnaryFn.Cos  => F.cos(v)
+      case UnaryFn.Tan  => F.tan(v)
+      case UnaryFn.Asin => F.asin(v)
+      case UnaryFn.Acos => F.acos(v)
+      case UnaryFn.Atan => F.atan(v)
+      case UnaryFn.Log  => F.logn(v)
+
+  private def applyScalar(fn: ScalarFn, v: Float32, s: Float)(using Source): Float32 =
+    fn match
+      case ScalarFn.Add => v + s
+      case ScalarFn.Sub => v - s
+      case ScalarFn.Mul => v * s
+      case ScalarFn.Div => v / s
+      case ScalarFn.Pow => F.pow(v, s)
+
+  // ── Phase 2: Fused multi-input — single GPU dispatch ───────
+
+  private def runFused(expr: GExpr, leaves: List[GLeaf])(using CyfraRuntime): Array[Float] =
+    val n = leaves.head.data.length
+    val numLeaves = leaves.size
+
+    // Build leaf-identity → packed-buffer index
+    val leafIndex: Map[AnyRef, Int] =
+      leaves.zipWithIndex.map((l, i) => (l.data.asInstanceOf[AnyRef], i)).toMap
+
+    // Pack all leaf data into one contiguous array:
+    //   [leaf0[0..n-1] | leaf1[0..n-1] | ... | leafK[0..n-1]]
+    val packedSize = numLeaves * n
+    val packed = new Array[Float](packedSize)
+    var li = 0
+    while li < numLeaves do
+      System.arraycopy(leaves(li).data, 0, packed, li * n, n)
+      li += 1
+    end while
+
+    transferLog(s"  CPU→GPU upload $packedSize floats (runFused, $numLeaves leaves × $n)")
+
+    val result = new Array[Float](n)
+
+    case class FusedLayout(inputs: GBuffer[Float32], output: GBuffer[Float32]) derives Layout
+
+    val program = GProgram.static[Int, FusedLayout](
+      layout = _ => FusedLayout(
+        inputs = GBuffer[Float32](packedSize),
+        output = GBuffer[Float32](n)
+      ),
+      dispatchSize = identity
+    ): layout =>
+      val idx = GIO.invocationId
+      val value = compileFused(expr, leafIndex, layout.inputs, idx, n)
+      for _ <- layout.output.write(idx, value)
+      yield GStruct.Empty()
+
+    GBufferRegion
+      .allocate[FusedLayout]
+      .map: layout =>
+        program.execute(n, layout)
+      .runUnsafe(
+        init = FusedLayout(
+          inputs = GBuffer(packed),
+          output = GBuffer[Float32](n)
+        ),
+        onDone = layout => layout.output.readArray(result)
+      )
+    transferLog(s"  GPU→CPU download $n floats (runFused)")
+    result
+
+  /** Walk the AST emitting Cyfra DSL code that reads each leaf from
+    * the packed input buffer at offset `leafIndex * n + invocationId`.
+    * All operations are fused into a single GPU kernel.
+    */
+  private def compileFused(
+      expr: GExpr,
+      leafIndex: Map[AnyRef, Int],
+      inputs: GBuffer[Float32],
+      idx: Int32,
+      n: Int
+  )(using Source): Float32 =
+    expr match
+      case leaf: GLeaf =>
+        val i = leafIndex(leaf.data.asInstanceOf[AnyRef])
+        if i == 0 then inputs.read(idx)
+        else inputs.read(idx + i * n)
+      case GUnaryOp(input, fn) =>
+        applyUnary(fn, compileFused(input, leafIndex, inputs, idx, n))
+      case GScalarOp(input, s, fn) =>
+        applyScalar(fn, compileFused(input, leafIndex, inputs, idx, n), s)
+      case GClampOp(input, f, c) =>
+        F.clamp(compileFused(input, leafIndex, inputs, idx, n), f, c)
+      case GBinaryOp(left, right, fn) =>
+        val l = compileFused(left, leafIndex, inputs, idx, n)
+        val r = compileFused(right, leafIndex, inputs, idx, n)
+        applyBinary(fn, l, r)
+
+  private def exprLabel(e: GExpr): String = e match
+    case _: GLeaf       => "Leaf"
+    case GUnaryOp(_, f) => s"Unary($f)"
+    case GScalarOp(_, s, f) => s"Scalar($f, $s)"
+    case GClampOp(_, lo, hi) => s"Clamp($lo, $hi)"
+    case GBinaryOp(_, _, f)  => s"Binary($f)"
+
+  private def applyBinary(fn: BinaryFn, a: Float32, b: Float32)(using Source): Float32 =
+    fn match
+      case BinaryFn.Add => a + b
+      case BinaryFn.Sub => a - b
+      case BinaryFn.Mul => a * b
+      case BinaryFn.Div => a / b
+
+end GExprCompiler
+
+// ── Entry point: Array[Float] → GExpr ──────────────────────
+
+extension (arr: Array[Float])
+  inline def gpu: GExpr = GLeaf(arr)

--- a/gvecxt/src/GArray.scala
+++ b/gvecxt/src/GArray.scala
@@ -14,12 +14,15 @@ import io.computenode.cyfra.foton.GFunction
 
 enum UnaryFn:
   case Neg, Abs, Exp, Sqrt, Sin, Cos, Tan, Asin, Acos, Atan, Log
+end UnaryFn
 
 enum ScalarFn:
   case Add, Sub, Mul, Div, Pow
+end ScalarFn
 
 enum BinaryFn:
   case Add, Sub, Mul, Div
+end BinaryFn
 
 // ── Expression tree ────────────────────────────────────────
 
@@ -60,8 +63,7 @@ sealed trait GExpr:
   // ── Materialize: compile AST → GPU dispatch → result ───
   def run(using CyfraRuntime): Array[Float] = GExprCompiler.run(this)
 
-  /** Phase 1: Walk the AST and compute the dimension at each node.
-    * All ops are elementwise, so propagation is trivial.
+  /** Phase 1: Walk the AST and compute the dimension at each node. All ops are elementwise, so propagation is trivial.
     * Catches dimension mismatches eagerly — no GPU work, no data movement.
     */
   def validateDimensions: Int = GExprCompiler.shapeAnalysis(this)
@@ -83,23 +85,23 @@ private[gpu] object GExprCompiler:
   private def transferLog(msg: => String): Unit =
     if logGExprTransfers then System.err.println(s"[GExpr] $msg")
 
-  /** Phase 1: Walk the AST and compute the dimension at each node.
-    * All ops are elementwise, so propagation is trivial.
+  /** Phase 1: Walk the AST and compute the dimension at each node. All ops are elementwise, so propagation is trivial.
     * Catches dimension mismatches eagerly — no GPU work, no data movement.
     */
   def shapeAnalysis(expr: GExpr): Int =
     expr match
-      case GLeaf(data)                 => data.length
-      case GUnaryOp(input, _)          => shapeAnalysis(input)
-      case GScalarOp(input, _, _)      => shapeAnalysis(input)
-      case GClampOp(input, _, _)       => shapeAnalysis(input)
-      case GBinaryOp(left, right, _)   =>
+      case GLeaf(data)               => data.length
+      case GUnaryOp(input, _)        => shapeAnalysis(input)
+      case GScalarOp(input, _, _)    => shapeAnalysis(input)
+      case GClampOp(input, _, _)     => shapeAnalysis(input)
+      case GBinaryOp(left, right, _) =>
         val ld = shapeAnalysis(left)
         val rd = shapeAnalysis(right)
         if ld != rd then
           throw new IllegalArgumentException(
             s"GExpr dimension mismatch: left has $ld elements, right has $rd"
           )
+        end if
         ld
 
   def run(expr: GExpr)(using CyfraRuntime): Array[Float] =
@@ -109,13 +111,15 @@ private[gpu] object GExprCompiler:
     leaves match
       case single :: Nil => runSingleInput(expr, single)
       case _             => runFused(expr, leaves)
+    end match
+  end run
 
   private def collectLeaves(expr: GExpr): List[GLeaf] =
     expr match
-      case l: GLeaf              => List(l)
-      case GUnaryOp(input, _)    => collectLeaves(input)
-      case GScalarOp(input, _, _) => collectLeaves(input)
-      case GClampOp(input, _, _) => collectLeaves(input)
+      case l: GLeaf                  => List(l)
+      case GUnaryOp(input, _)        => collectLeaves(input)
+      case GScalarOp(input, _, _)    => collectLeaves(input)
+      case GClampOp(input, _, _)     => collectLeaves(input)
       case GBinaryOp(left, right, _) =>
         val ll = collectLeaves(left)
         val rl = collectLeaves(right)
@@ -131,6 +135,7 @@ private[gpu] object GExprCompiler:
     val result: Array[Float] = gf.run(leaf.data)
     transferLog(s"  GPU→CPU download ${result.length} floats (runSingleInput)")
     result
+  end runSingleInput
 
   private def compileSingle(expr: GExpr, leaf: GLeaf, x: Float32)(using Source): Float32 =
     expr match
@@ -200,10 +205,11 @@ private[gpu] object GExprCompiler:
     case class FusedLayout(inputs: GBuffer[Float32], output: GBuffer[Float32]) derives Layout
 
     val program = GProgram.static[Int, FusedLayout](
-      layout = _ => FusedLayout(
-        inputs = GBuffer[Float32](packedSize),
-        output = GBuffer[Float32](n)
-      ),
+      layout = _ =>
+        FusedLayout(
+          inputs = GBuffer[Float32](packedSize),
+          output = GBuffer[Float32](n)
+        ),
       dispatchSize = identity
     ): layout =>
       val idx = GIO.invocationId
@@ -224,10 +230,10 @@ private[gpu] object GExprCompiler:
       )
     transferLog(s"  GPU→CPU download $n floats (runFused)")
     result
+  end runFused
 
-  /** Walk the AST emitting Cyfra DSL code that reads each leaf from
-    * the packed input buffer at offset `leafIndex * n + invocationId`.
-    * All operations are fused into a single GPU kernel.
+  /** Walk the AST emitting Cyfra DSL code that reads each leaf from the packed input buffer at offset
+    * `leafIndex * n + invocationId`. All operations are fused into a single GPU kernel.
     */
   private def compileFused(
       expr: GExpr,
@@ -241,6 +247,7 @@ private[gpu] object GExprCompiler:
         val i = leafIndex(leaf.data.asInstanceOf[AnyRef])
         if i == 0 then inputs.read(idx)
         else inputs.read(idx + i * n)
+        end if
       case GUnaryOp(input, fn) =>
         applyUnary(fn, compileFused(input, leafIndex, inputs, idx, n))
       case GScalarOp(input, s, fn) =>
@@ -253,9 +260,9 @@ private[gpu] object GExprCompiler:
         applyBinary(fn, l, r)
 
   private def exprLabel(e: GExpr): String = e match
-    case _: GLeaf       => "Leaf"
-    case GUnaryOp(_, f) => s"Unary($f)"
-    case GScalarOp(_, s, f) => s"Scalar($f, $s)"
+    case _: GLeaf            => "Leaf"
+    case GUnaryOp(_, f)      => s"Unary($f)"
+    case GScalarOp(_, s, f)  => s"Scalar($f, $s)"
     case GClampOp(_, lo, hi) => s"Clamp($lo, $hi)"
     case GBinaryOp(_, _, f)  => s"Binary($f)"
 
@@ -270,5 +277,5 @@ end GExprCompiler
 
 // ── Entry point: Array[Float] → GExpr ──────────────────────
 
-extension (arr: Array[Float])
-  inline def gpu: GExpr = GLeaf(arr)
+extension (arr: Array[Float]) inline def gpu: GExpr = GLeaf(arr)
+end extension

--- a/gvecxt/src/GNDArray.scala
+++ b/gvecxt/src/GNDArray.scala
@@ -64,6 +64,13 @@ sealed trait GNDExpr:
     * regardless of pipeline depth. Does not require a CyfraRuntime.
     */
   def runCpu: GNDLeaf = GNDExprCompiler.runCpu(this)
+
+  /** Fused CPU evaluation with fine-grained parallelism: same single-pass AST walk as [[runCpu]] but splits the element
+    * range across all available CPU cores using a Java parallel IntStream. Each element is still evaluated via
+    * recursive AST traversal; the concurrency comes from processing multiple elements simultaneously on different
+    * threads.
+    */
+  def runCpuParallel: GNDLeaf = GNDExprCompiler.runCpuParallel(this)
 end GNDExpr
 
 // ── AST node types ─────────────────────────────────────────
@@ -439,6 +446,19 @@ private[gpu] object GNDExprCompiler:
     val strides = GNDArray.colMajorStrides(outShape)
     GNDLeaf(out, outShape, strides, 0)
   end runCpu
+
+  /** Fused CPU evaluation with fine-grained parallelism: splits the element loop across available CPU cores using a
+    * Java parallel IntStream. The AST is walked once per element (identical to [[runCpu]]) but multiple elements are
+    * evaluated concurrently on different threads.
+    */
+  def runCpuParallel(expr: GNDExpr): GNDLeaf =
+    val outShape = GNDShapeAnalysis.analyze(expr)
+    val n = GNDShapeAnalysis.numel(outShape)
+    val out = new Array[Float](n)
+    java.util.stream.IntStream.range(0, n).parallel().forEach((i: Int) => out(i) = evalElement(expr, i))
+    val strides = GNDArray.colMajorStrides(outShape)
+    GNDLeaf(out, outShape, strides, 0)
+  end runCpuParallel
 
   /** Recursively evaluate the expression tree for a single flat index. */
   private def evalElement(expr: GNDExpr, i: Int): Float =

--- a/gvecxt/src/GNDArray.scala
+++ b/gvecxt/src/GNDArray.scala
@@ -1,0 +1,478 @@
+package vecxt.gpu
+
+import io.computenode.cyfra.core.CyfraRuntime
+
+// ── GNDExpr: N-dimensional expression tree for GPU ─────────
+
+/** An N-dimensional GPU expression that tracks shape and strides.
+  *
+  * All shape/stride metadata lives on the CPU. The backing data is a flat
+  * `Array[Float]` that is only uploaded to GPU at materialisation time.
+  *
+  * Column-major by default (matching vecxt.NDArray conventions).
+  */
+sealed trait GNDExpr:
+
+  // ── Unary elementwise (builds AST, no GPU work) ────────
+  def neg: GNDExpr = GNDUnaryOp(this, UnaryFn.Neg)
+  def abs: GNDExpr = GNDUnaryOp(this, UnaryFn.Abs)
+  def exp: GNDExpr = GNDUnaryOp(this, UnaryFn.Exp)
+  def sqrt: GNDExpr = GNDUnaryOp(this, UnaryFn.Sqrt)
+  def sin: GNDExpr = GNDUnaryOp(this, UnaryFn.Sin)
+  def cos: GNDExpr = GNDUnaryOp(this, UnaryFn.Cos)
+  def tan: GNDExpr = GNDUnaryOp(this, UnaryFn.Tan)
+  def asin: GNDExpr = GNDUnaryOp(this, UnaryFn.Asin)
+  def acos: GNDExpr = GNDUnaryOp(this, UnaryFn.Acos)
+  def atan: GNDExpr = GNDUnaryOp(this, UnaryFn.Atan)
+  def log: GNDExpr = GNDUnaryOp(this, UnaryFn.Log)
+
+  // ── Scalar arithmetic (builds AST) ─────────────────────
+  def +(d: Float): GNDExpr = GNDScalarOp(this, d, ScalarFn.Add)
+  def -(d: Float): GNDExpr = GNDScalarOp(this, d, ScalarFn.Sub)
+  def *(d: Float): GNDExpr = GNDScalarOp(this, d, ScalarFn.Mul)
+  def /(d: Float): GNDExpr = GNDScalarOp(this, d, ScalarFn.Div)
+  def **(power: Float): GNDExpr = GNDScalarOp(this, power, ScalarFn.Pow)
+
+  def clamp(floor: Float, ceil: Float): GNDExpr =
+    GNDClampOp(this, floor, ceil)
+
+  // ── Elementwise binary — requires matching shapes ──────
+  def +(other: GNDExpr): GNDExpr = GNDBinaryOp(this, other, BinaryFn.Add)
+  def -(other: GNDExpr): GNDExpr = GNDBinaryOp(this, other, BinaryFn.Sub)
+  def *(other: GNDExpr): GNDExpr = GNDBinaryOp(this, other, BinaryFn.Mul)
+  def /(other: GNDExpr): GNDExpr = GNDBinaryOp(this, other, BinaryFn.Div)
+
+  // ── Explicit broadcast (builds AST, zero-copy) ────────
+  def broadcastTo(targetShape: Array[Int]): GNDExpr = GNDBroadcastOp(this, targetShape.clone())
+
+  // ── Matrix multiply (builds AST) ──────────────────────
+  def @@(other: GNDExpr): GNDExpr = GNDMatMulOp(this, other)
+
+  // ── Reshape / transpose (builds AST, zero-copy) ───────
+  def reshape(newShape: Array[Int]): GNDExpr = GNDReshapeOp(this, newShape.clone())
+  def T: GNDExpr = GNDTransposeOp(this)
+
+  /** Phase 1: validate shapes across the whole tree. Returns the output shape. */
+  def validateShape: Array[Int] = GNDShapeAnalysis.analyze(this)
+
+  /** Lower to GExpr, dispatch to GPU, wrap result back as GNDLeaf.
+    * Requires all leaves to be contiguous col-major with offset=0.
+    * Throws UnsupportedOperationException for broadcast, matmul, transpose.
+    */
+  def run(using CyfraRuntime): GNDLeaf = GNDExprCompiler.run(this)
+
+  /** Fused CPU evaluation: walks the AST per-element in a single pass.
+    * No intermediate arrays — constant memory regardless of pipeline depth.
+    * Does not require a CyfraRuntime.
+    */
+  def runCpu: GNDLeaf = GNDExprCompiler.runCpu(this)
+end GNDExpr
+
+// ── AST node types ─────────────────────────────────────────
+
+/** Leaf: raw data with shape, strides, offset — models a strided view. */
+case class GNDLeaf(
+    data: Array[Float],
+    shape: Array[Int],
+    strides: Array[Int],
+    offset: Int
+) extends GNDExpr
+
+case class GNDUnaryOp(input: GNDExpr, fn: UnaryFn) extends GNDExpr
+case class GNDScalarOp(input: GNDExpr, scalar: Float, fn: ScalarFn) extends GNDExpr
+case class GNDClampOp(input: GNDExpr, floor: Float, ceil: Float) extends GNDExpr
+case class GNDBinaryOp(left: GNDExpr, right: GNDExpr, fn: BinaryFn) extends GNDExpr
+case class GNDBroadcastOp(input: GNDExpr, targetShape: Array[Int]) extends GNDExpr
+case class GNDMatMulOp(left: GNDExpr, right: GNDExpr) extends GNDExpr
+case class GNDReshapeOp(input: GNDExpr, newShape: Array[Int]) extends GNDExpr
+case class GNDTransposeOp(input: GNDExpr) extends GNDExpr
+
+// ── Shape analysis: pure CPU, no GPU work ──────────────────
+
+object GNDShapeAnalysis:
+
+  /** Walk the AST and compute the output shape at each node.
+    *
+    * Rules:
+    *  - Leaf         → leaf.shape
+    *  - Unary/Scalar/Clamp → same shape as input
+    *  - Binary       → require exact shape match (use broadcastTo first)
+    *  - Broadcast    → validate broadcast compatibility, return targetShape
+    *  - MatMul       → standard matmul shape rule: [..., M, K] @@ [..., K, N] → [..., M, N]
+    *  - Reshape      → validate numel match, return newShape
+    *  - Transpose    → reversed shape
+    *
+    * Throws `IllegalArgumentException` on any incompatibility.
+    */
+  def analyze(expr: GNDExpr): Array[Int] =
+    expr match
+      case GNDLeaf(_, shape, _, _)       => shape.clone()
+      case GNDUnaryOp(input, _)          => analyze(input)
+      case GNDScalarOp(input, _, _)      => analyze(input)
+      case GNDClampOp(input, _, _)       => analyze(input)
+      case GNDBinaryOp(left, right, _)   =>
+        val ls = analyze(left)
+        val rs = analyze(right)
+        requireSameShape(ls, rs)
+        ls
+      case GNDBroadcastOp(input, targetShape) =>
+        val is = analyze(input)
+        validateBroadcast(is, targetShape)
+        targetShape.clone()
+      case GNDMatMulOp(left, right)      =>
+        val ls = analyze(left)
+        val rs = analyze(right)
+        matmulShapeOrThrow(ls, rs)
+      case GNDReshapeOp(input, newShape) =>
+        val is = analyze(input)
+        val inNumel = numel(is)
+        val outNumel = numel(newShape)
+        if inNumel != outNumel then
+          throw new IllegalArgumentException(
+            s"GNDExpr reshape: cannot reshape [${is.mkString(",")}] ($inNumel elements) " +
+              s"to [${newShape.mkString(",")}] ($outNumel elements)"
+          )
+        newShape.clone()
+      case GNDTransposeOp(input) =>
+        val is = analyze(input)
+        if is.length < 2 then
+          throw new IllegalArgumentException(
+            s"GNDExpr transpose requires at least 2 dimensions, got [${is.mkString(",")}]"
+          )
+        is.reverse
+
+  // ── Shape matching for binary ops ────────────────────────
+
+  /** Require that two shapes are identical rank and element-wise equal. */
+  private def requireSameShape(a: Array[Int], b: Array[Int]): Unit =
+    if a.length != b.length then
+      throw new IllegalArgumentException(
+        s"GNDExpr binary: shape mismatch — [${a.mkString(",")}] vs [${b.mkString(",")}] " +
+          s"(rank ${a.length} != ${b.length}). Use .broadcastTo to align shapes explicitly."
+      )
+    var i = 0
+    while i < a.length do
+      if a(i) != b(i) then
+        throw new IllegalArgumentException(
+          s"GNDExpr binary: shape mismatch — [${a.mkString(",")}] vs [${b.mkString(",")}] " +
+            s"at dimension $i (${a(i)} vs ${b(i)}). Use .broadcastTo to align shapes explicitly."
+        )
+      i += 1
+    end while
+
+  // ── Broadcast validation ─────────────────────────────────
+
+  /** Validate that `inputShape` can be broadcast to `targetShape`. */
+  private[gpu] def validateBroadcast(inputShape: Array[Int], targetShape: Array[Int]): Unit =
+    if inputShape.length > targetShape.length then
+      throw new IllegalArgumentException(
+        s"GNDExpr broadcast: cannot broadcast [${inputShape.mkString(",")}] to [${targetShape.mkString(",")}] — " +
+          s"source has more dimensions (${inputShape.length}) than target (${targetShape.length})"
+      )
+    val n = targetShape.length
+    var i = 0
+    while i < n do
+      val srcIdx = i - (n - inputShape.length)
+      val srcDim = if srcIdx < 0 then 1 else inputShape(srcIdx)
+      val tgtDim = targetShape(i)
+      if srcDim != tgtDim && srcDim != 1 then
+        throw new IllegalArgumentException(
+          s"GNDExpr broadcast: cannot broadcast [${inputShape.mkString(",")}] to [${targetShape.mkString(",")}] — " +
+            s"incompatible at dimension $i ($srcDim vs $tgtDim)"
+        )
+      i += 1
+    end while
+
+  /** Compute broadcast output shape for two shapes. Used internally by matmul batch dims. */
+  private[gpu] def broadcastShapeOrThrow(a: Array[Int], b: Array[Int]): Array[Int] =
+    val n = math.max(a.length, b.length)
+    val out = new Array[Int](n)
+    var i = 0
+    while i < n do
+      val ai = i - (n - a.length)
+      val bi = i - (n - b.length)
+      val da = if ai < 0 then 1 else a(ai)
+      val db = if bi < 0 then 1 else b(bi)
+      if da == db then out(i) = da
+      else if da == 1 then out(i) = db
+      else if db == 1 then out(i) = da
+      else
+        throw new IllegalArgumentException(
+          s"GNDExpr broadcast: incompatible shapes [${a.mkString(",")}] and [${b.mkString(",")}] " +
+            s"at dimension $i ($da vs $db)"
+        )
+      i += 1
+    end while
+    out
+
+  // ── MatMul shape ─────────────────────────────────────────
+
+  /** Compute matmul output shape.
+    *
+    * Supports:
+    *  - 2D × 2D: [M,K] @@ [K,N] → [M,N]
+    *  - Batched:  [...,M,K] @@ [...,K,N] → [...,M,N]
+    *    where batch dims are broadcast.
+    *  - 1D × 2D: [K] @@ [K,N] → [N]        (vector-matrix)
+    *  - 2D × 1D: [M,K] @@ [K] → [M]        (matrix-vector)
+    *  - 1D × 1D: [K] @@ [K] → []            (dot product → scalar)
+    */
+  private[gpu] def matmulShapeOrThrow(a: Array[Int], b: Array[Int]): Array[Int] =
+    // Handle 1D cases by temporarily promoting to 2D
+    val (aEff, aSqueezeFront) = if a.length == 1 then (Array(1, a(0)), true) else (a, false)
+    val (bEff, aSqueezeBack) = if b.length == 1 then (Array(b(0), 1), true) else (b, false)
+
+    val aRank = aEff.length
+    val bRank = bEff.length
+    val m = aEff(aRank - 2)
+    val k1 = aEff(aRank - 1)
+    val k2 = bEff(bRank - 2)
+    val n = bEff(bRank - 1)
+
+    if k1 != k2 then
+      throw new IllegalArgumentException(
+        s"GNDExpr matmul: inner dimensions don't match — " +
+          s"[${a.mkString(",")}] @@ [${b.mkString(",")}]: $k1 != $k2"
+      )
+
+    // Broadcast batch dims (everything except last 2)
+    val aBatch = aEff.take(aRank - 2)
+    val bBatch = bEff.take(bRank - 2)
+    val batchShape = if aBatch.isEmpty && bBatch.isEmpty then Array.empty[Int]
+                     else broadcastShapeOrThrow(aBatch, bBatch)
+
+    // Build output shape, then un-squeeze if we promoted 1D inputs
+    val fullShape = batchShape ++ Array(m, n)
+
+    // Undo the 1D promotions
+    if aSqueezeFront && aSqueezeBack then
+      fullShape.drop(fullShape.length - 2).dropRight(1) // scalar [] — but represented as empty
+      Array.empty[Int]
+    else if aSqueezeFront then
+      // Remove the M=1 dim from output
+      batchShape ++ Array(n)
+    else if aSqueezeBack then
+      // Remove the N=1 dim from output
+      batchShape ++ Array(m)
+    else
+      fullShape
+  end matmulShapeOrThrow
+
+  private[gpu] def numel(shape: Array[Int]): Int =
+    if shape.isEmpty then 1
+    else
+      var prod = 1
+      var i = 0
+      while i < shape.length do
+        prod *= shape(i)
+        i += 1
+      end while
+      prod
+
+end GNDShapeAnalysis
+
+// ── Entry points ───────────────────────────────────────────
+
+/** Construct a GNDLeaf from a flat array and a shape, using column-major strides. */
+object GNDArray:
+
+  def apply(data: Array[Float], shape: Array[Int]): GNDLeaf =
+    val strides = colMajorStrides(shape)
+    requireValidLeaf(data, shape, strides, 0)
+    GNDLeaf(data, shape.clone(), strides, 0)
+
+  def apply(data: Array[Float], shape: Array[Int], strides: Array[Int], offset: Int = 0): GNDLeaf =
+    requireValidLeaf(data, shape, strides, offset)
+    GNDLeaf(data, shape.clone(), strides.clone(), offset)
+
+  /** 1D convenience. */
+  def fromArray(data: Array[Float]): GNDLeaf =
+    GNDLeaf(data, Array(data.length), Array(1), 0)
+
+  /** 2D convenience: matrix with rows × cols, column-major. */
+  def matrix(data: Array[Float], rows: Int, cols: Int): GNDLeaf =
+    apply(data, Array(rows, cols))
+
+  private[gpu] def colMajorStrides(shape: Array[Int]): Array[Int] =
+    val s = new Array[Int](shape.length)
+    if shape.nonEmpty then
+      s(0) = 1
+      var i = 1
+      while i < shape.length do
+        s(i) = s(i - 1) * shape(i - 1)
+        i += 1
+      end while
+    end if
+    s
+
+  private def requireValidLeaf(data: Array[Float], shape: Array[Int], strides: Array[Int], offset: Int): Unit =
+    if shape.length != strides.length then
+      throw new IllegalArgumentException(
+        s"GNDArray: shape rank ${shape.length} != strides rank ${strides.length}"
+      )
+    if shape.exists(_ < 0) then
+      throw new IllegalArgumentException(
+        s"GNDArray: shape has negative dimension: [${shape.mkString(",")}]"
+      )
+    if offset < 0 then
+      throw new IllegalArgumentException(s"GNDArray: negative offset $offset")
+    // Check that every reachable index stays within data bounds
+    if shape.nonEmpty then
+      var maxIdx = offset
+      var i = 0
+      while i < shape.length do
+        if shape(i) > 0 then maxIdx += (shape(i) - 1) * math.abs(strides(i))
+        i += 1
+      end while
+      if maxIdx >= data.length then
+        throw new IllegalArgumentException(
+          s"GNDArray: max reachable index $maxIdx >= data.length ${data.length} " +
+            s"(shape=[${shape.mkString(",")}], strides=[${strides.mkString(",")}], offset=$offset)"
+        )
+    end if
+  end requireValidLeaf
+
+end GNDArray
+
+// ── GNDExpr compiler: lower to GExpr for GPU dispatch ──────
+
+/** Set to true to log GNDExpr CPU↔GPU transfer events to stderr. */
+var logGNDExprTransfers: Boolean = false
+
+private[gpu] object GNDExprCompiler:
+
+  private def transferLog(msg: => String): Unit =
+    if logGNDExprTransfers then System.err.println(s"[GNDExpr] $msg")
+
+  /** Validate shapes, lower to GExpr, run on GPU, wrap result. */
+  def run(expr: GNDExpr)(using CyfraRuntime): GNDLeaf =
+    val outShape = GNDShapeAnalysis.analyze(expr)
+    val n = GNDShapeAnalysis.numel(outShape)
+    transferLog(s"run: shape=[${outShape.mkString(",")}] ($n elements), lowering to GExpr")
+    val lowered = lower(expr)
+    transferLog(s"  lowered — delegating to GExprCompiler")
+    val result = GExprCompiler.run(lowered)
+    transferLog(s"  GPU→CPU done, wrapping $n floats as GNDLeaf shape=[${outShape.mkString(",")}]")
+    val strides = GNDArray.colMajorStrides(outShape)
+    GNDLeaf(result, outShape, strides, 0)
+
+  /** Recursively lower a GNDExpr tree to a flat GExpr tree.
+    *
+    * Elementwise ops map 1:1. Reshape is a no-op (same flat data).
+    * Broadcast, matmul, and transpose throw — they require non-trivial
+    * GPU kernels that the 1D GExpr path doesn't support yet.
+    */
+  private def lower(expr: GNDExpr): GExpr =
+    expr match
+      case leaf: GNDLeaf                  =>
+        requireContiguous(leaf)
+        transferLog(s"  lower: GNDLeaf(${leaf.data.length} floats, shape=[${leaf.shape.mkString(",")}]) → GLeaf")
+        GLeaf(leaf.data)
+      case GNDUnaryOp(input, fn)          => GUnaryOp(lower(input), fn)
+      case GNDScalarOp(input, s, fn)      => GScalarOp(lower(input), s, fn)
+      case GNDClampOp(input, f, c)        => GClampOp(lower(input), f, c)
+      case GNDBinaryOp(left, right, fn)   => GBinaryOp(lower(left), lower(right), fn)
+      case GNDReshapeOp(input, _)         => lower(input) // same flat data
+      case _: GNDBroadcastOp =>
+        throw new UnsupportedOperationException(
+          "GNDExpr broadcast lowering to GExpr is not yet supported"
+        )
+      case _: GNDMatMulOp =>
+        throw new UnsupportedOperationException(
+          "GNDExpr matmul lowering to GExpr is not yet supported"
+        )
+      case _: GNDTransposeOp =>
+        throw new UnsupportedOperationException(
+          "GNDExpr transpose lowering to GExpr is not yet supported — non-contiguous layout"
+        )
+
+  /** Ensure a leaf has offset=0, col-major strides, and data.length == numel. */
+  private def requireContiguous(leaf: GNDLeaf): Unit =
+    if leaf.offset != 0 then
+      throw new UnsupportedOperationException(
+        s"GNDExpr lowering requires offset=0, got ${leaf.offset}"
+      )
+    val expected = GNDArray.colMajorStrides(leaf.shape)
+    if !java.util.Arrays.equals(leaf.strides, expected) then
+      throw new UnsupportedOperationException(
+        s"GNDExpr lowering requires contiguous col-major strides [${expected.mkString(",")}], " +
+          s"got [${leaf.strides.mkString(",")}]"
+      )
+    val n = GNDShapeAnalysis.numel(leaf.shape)
+    if leaf.data.length != n then
+      throw new UnsupportedOperationException(
+        s"GNDExpr lowering requires data.length == numel(shape) ($n), got ${leaf.data.length}"
+      )
+
+  // ── Fused CPU backend ──────────────────────────────────
+
+  /** Fused CPU evaluation: single pass, no intermediate arrays. */
+  def runCpu(expr: GNDExpr): GNDLeaf =
+    val outShape = GNDShapeAnalysis.analyze(expr)
+    val n = GNDShapeAnalysis.numel(outShape)
+    val out = new Array[Float](n)
+    var i = 0
+    while i < n do
+      out(i) = evalElement(expr, i)
+      i += 1
+    end while
+    val strides = GNDArray.colMajorStrides(outShape)
+    GNDLeaf(out, outShape, strides, 0)
+
+  /** Recursively evaluate the expression tree for a single flat index. */
+  private def evalElement(expr: GNDExpr, i: Int): Float =
+    expr match
+      case leaf: GNDLeaf =>
+        leaf.data(leaf.offset + i) // contiguous col-major: flat index == data index
+      case GNDUnaryOp(input, fn) =>
+        val v = evalElement(input, i)
+        cpuUnary(fn, v)
+      case GNDScalarOp(input, s, fn) =>
+        val v = evalElement(input, i)
+        cpuScalar(fn, v, s)
+      case GNDClampOp(input, floor, ceil) =>
+        val v = evalElement(input, i)
+        math.max(floor, math.min(ceil, v))
+      case GNDBinaryOp(left, right, fn) =>
+        val l = evalElement(left, i)
+        val r = evalElement(right, i)
+        cpuBinary(fn, l, r)
+      case GNDReshapeOp(input, _) =>
+        evalElement(input, i) // same flat data
+      case _: GNDBroadcastOp =>
+        throw new UnsupportedOperationException("runCpu: broadcast not yet supported")
+      case _: GNDMatMulOp =>
+        throw new UnsupportedOperationException("runCpu: matmul not yet supported")
+      case _: GNDTransposeOp =>
+        throw new UnsupportedOperationException("runCpu: transpose not yet supported")
+
+  private def cpuUnary(fn: UnaryFn, v: Float): Float =
+    fn match
+      case UnaryFn.Neg  => -v
+      case UnaryFn.Abs  => math.abs(v)
+      case UnaryFn.Exp  => math.exp(v.toDouble).toFloat
+      case UnaryFn.Sqrt => math.sqrt(v.toDouble).toFloat
+      case UnaryFn.Sin  => math.sin(v.toDouble).toFloat
+      case UnaryFn.Cos  => math.cos(v.toDouble).toFloat
+      case UnaryFn.Tan  => math.tan(v.toDouble).toFloat
+      case UnaryFn.Asin => math.asin(v.toDouble).toFloat
+      case UnaryFn.Acos => math.acos(v.toDouble).toFloat
+      case UnaryFn.Atan => math.atan(v.toDouble).toFloat
+      case UnaryFn.Log  => math.log(v.toDouble).toFloat
+
+  private def cpuScalar(fn: ScalarFn, v: Float, s: Float): Float =
+    fn match
+      case ScalarFn.Add => v + s
+      case ScalarFn.Sub => v - s
+      case ScalarFn.Mul => v * s
+      case ScalarFn.Div => v / s
+      case ScalarFn.Pow => math.pow(v.toDouble, s.toDouble).toFloat
+
+  private def cpuBinary(fn: BinaryFn, a: Float, b: Float): Float =
+    fn match
+      case BinaryFn.Add => a + b
+      case BinaryFn.Sub => a - b
+      case BinaryFn.Mul => a * b
+      case BinaryFn.Div => a / b
+
+end GNDExprCompiler

--- a/gvecxt/src/GNDArray.scala
+++ b/gvecxt/src/GNDArray.scala
@@ -6,8 +6,8 @@ import io.computenode.cyfra.core.CyfraRuntime
 
 /** An N-dimensional GPU expression that tracks shape and strides.
   *
-  * All shape/stride metadata lives on the CPU. The backing data is a flat
-  * `Array[Float]` that is only uploaded to GPU at materialisation time.
+  * All shape/stride metadata lives on the CPU. The backing data is a flat `Array[Float]` that is only uploaded to GPU
+  * at materialisation time.
   *
   * Column-major by default (matching vecxt.NDArray conventions).
   */
@@ -55,15 +55,13 @@ sealed trait GNDExpr:
   /** Phase 1: validate shapes across the whole tree. Returns the output shape. */
   def validateShape: Array[Int] = GNDShapeAnalysis.analyze(this)
 
-  /** Lower to GExpr, dispatch to GPU, wrap result back as GNDLeaf.
-    * Requires all leaves to be contiguous col-major with offset=0.
-    * Throws UnsupportedOperationException for broadcast, matmul, transpose.
+  /** Lower to GExpr, dispatch to GPU, wrap result back as GNDLeaf. Requires all leaves to be contiguous col-major with
+    * offset=0. Throws UnsupportedOperationException for broadcast, matmul, transpose.
     */
   def run(using CyfraRuntime): GNDLeaf = GNDExprCompiler.run(this)
 
-  /** Fused CPU evaluation: walks the AST per-element in a single pass.
-    * No intermediate arrays — constant memory regardless of pipeline depth.
-    * Does not require a CyfraRuntime.
+  /** Fused CPU evaluation: walks the AST per-element in a single pass. No intermediate arrays — constant memory
+    * regardless of pipeline depth. Does not require a CyfraRuntime.
     */
   def runCpu: GNDLeaf = GNDExprCompiler.runCpu(this)
 end GNDExpr
@@ -94,23 +92,23 @@ object GNDShapeAnalysis:
   /** Walk the AST and compute the output shape at each node.
     *
     * Rules:
-    *  - Leaf         → leaf.shape
-    *  - Unary/Scalar/Clamp → same shape as input
-    *  - Binary       → require exact shape match (use broadcastTo first)
-    *  - Broadcast    → validate broadcast compatibility, return targetShape
-    *  - MatMul       → standard matmul shape rule: [..., M, K] @@ [..., K, N] → [..., M, N]
-    *  - Reshape      → validate numel match, return newShape
-    *  - Transpose    → reversed shape
+    *   - Leaf → leaf.shape
+    *   - Unary/Scalar/Clamp → same shape as input
+    *   - Binary → require exact shape match (use broadcastTo first)
+    *   - Broadcast → validate broadcast compatibility, return targetShape
+    *   - MatMul → standard matmul shape rule: [..., M, K] @@ [..., K, N] → [..., M, N]
+    *   - Reshape → validate numel match, return newShape
+    *   - Transpose → reversed shape
     *
     * Throws `IllegalArgumentException` on any incompatibility.
     */
   def analyze(expr: GNDExpr): Array[Int] =
     expr match
-      case GNDLeaf(_, shape, _, _)       => shape.clone()
-      case GNDUnaryOp(input, _)          => analyze(input)
-      case GNDScalarOp(input, _, _)      => analyze(input)
-      case GNDClampOp(input, _, _)       => analyze(input)
-      case GNDBinaryOp(left, right, _)   =>
+      case GNDLeaf(_, shape, _, _)     => shape.clone()
+      case GNDUnaryOp(input, _)        => analyze(input)
+      case GNDScalarOp(input, _, _)    => analyze(input)
+      case GNDClampOp(input, _, _)     => analyze(input)
+      case GNDBinaryOp(left, right, _) =>
         val ls = analyze(left)
         val rs = analyze(right)
         requireSameShape(ls, rs)
@@ -119,7 +117,7 @@ object GNDShapeAnalysis:
         val is = analyze(input)
         validateBroadcast(is, targetShape)
         targetShape.clone()
-      case GNDMatMulOp(left, right)      =>
+      case GNDMatMulOp(left, right) =>
         val ls = analyze(left)
         val rs = analyze(right)
         matmulShapeOrThrow(ls, rs)
@@ -132,6 +130,7 @@ object GNDShapeAnalysis:
             s"GNDExpr reshape: cannot reshape [${is.mkString(",")}] ($inNumel elements) " +
               s"to [${newShape.mkString(",")}] ($outNumel elements)"
           )
+        end if
         newShape.clone()
       case GNDTransposeOp(input) =>
         val is = analyze(input)
@@ -139,6 +138,7 @@ object GNDShapeAnalysis:
           throw new IllegalArgumentException(
             s"GNDExpr transpose requires at least 2 dimensions, got [${is.mkString(",")}]"
           )
+        end if
         is.reverse
 
   // ── Shape matching for binary ops ────────────────────────
@@ -150,6 +150,7 @@ object GNDShapeAnalysis:
         s"GNDExpr binary: shape mismatch — [${a.mkString(",")}] vs [${b.mkString(",")}] " +
           s"(rank ${a.length} != ${b.length}). Use .broadcastTo to align shapes explicitly."
       )
+    end if
     var i = 0
     while i < a.length do
       if a(i) != b(i) then
@@ -157,8 +158,10 @@ object GNDShapeAnalysis:
           s"GNDExpr binary: shape mismatch — [${a.mkString(",")}] vs [${b.mkString(",")}] " +
             s"at dimension $i (${a(i)} vs ${b(i)}). Use .broadcastTo to align shapes explicitly."
         )
+      end if
       i += 1
     end while
+  end requireSameShape
 
   // ── Broadcast validation ─────────────────────────────────
 
@@ -169,6 +172,7 @@ object GNDShapeAnalysis:
         s"GNDExpr broadcast: cannot broadcast [${inputShape.mkString(",")}] to [${targetShape.mkString(",")}] — " +
           s"source has more dimensions (${inputShape.length}) than target (${targetShape.length})"
       )
+    end if
     val n = targetShape.length
     var i = 0
     while i < n do
@@ -180,8 +184,10 @@ object GNDShapeAnalysis:
           s"GNDExpr broadcast: cannot broadcast [${inputShape.mkString(",")}] to [${targetShape.mkString(",")}] — " +
             s"incompatible at dimension $i ($srcDim vs $tgtDim)"
         )
+      end if
       i += 1
     end while
+  end validateBroadcast
 
   /** Compute broadcast output shape for two shapes. Used internally by matmul batch dims. */
   private[gpu] def broadcastShapeOrThrow(a: Array[Int], b: Array[Int]): Array[Int] =
@@ -201,21 +207,22 @@ object GNDShapeAnalysis:
           s"GNDExpr broadcast: incompatible shapes [${a.mkString(",")}] and [${b.mkString(",")}] " +
             s"at dimension $i ($da vs $db)"
         )
+      end if
       i += 1
     end while
     out
+  end broadcastShapeOrThrow
 
   // ── MatMul shape ─────────────────────────────────────────
 
   /** Compute matmul output shape.
     *
     * Supports:
-    *  - 2D × 2D: [M,K] @@ [K,N] → [M,N]
-    *  - Batched:  [...,M,K] @@ [...,K,N] → [...,M,N]
-    *    where batch dims are broadcast.
-    *  - 1D × 2D: [K] @@ [K,N] → [N]        (vector-matrix)
-    *  - 2D × 1D: [M,K] @@ [K] → [M]        (matrix-vector)
-    *  - 1D × 1D: [K] @@ [K] → []            (dot product → scalar)
+    *   - 2D × 2D: [M,K] @@ [K,N] → [M,N]
+    *   - Batched: [...,M,K] @@ [...,K,N] → [...,M,N] where batch dims are broadcast.
+    *   - 1D × 2D: [K] @@ [K,N] → [N] (vector-matrix)
+    *   - 2D × 1D: [M,K] @@ [K] → [M] (matrix-vector)
+    *   - 1D × 1D: [K] @@ [K] → [] (dot product → scalar)
     */
   private[gpu] def matmulShapeOrThrow(a: Array[Int], b: Array[Int]): Array[Int] =
     // Handle 1D cases by temporarily promoting to 2D
@@ -234,12 +241,14 @@ object GNDShapeAnalysis:
         s"GNDExpr matmul: inner dimensions don't match — " +
           s"[${a.mkString(",")}] @@ [${b.mkString(",")}]: $k1 != $k2"
       )
+    end if
 
     // Broadcast batch dims (everything except last 2)
     val aBatch = aEff.take(aRank - 2)
     val bBatch = bEff.take(bRank - 2)
-    val batchShape = if aBatch.isEmpty && bBatch.isEmpty then Array.empty[Int]
-                     else broadcastShapeOrThrow(aBatch, bBatch)
+    val batchShape =
+      if aBatch.isEmpty && bBatch.isEmpty then Array.empty[Int]
+      else broadcastShapeOrThrow(aBatch, bBatch)
 
     // Build output shape, then un-squeeze if we promoted 1D inputs
     val fullShape = batchShape ++ Array(m, n)
@@ -254,8 +263,8 @@ object GNDShapeAnalysis:
     else if aSqueezeBack then
       // Remove the N=1 dim from output
       batchShape ++ Array(m)
-    else
-      fullShape
+    else fullShape
+    end if
   end matmulShapeOrThrow
 
   private[gpu] def numel(shape: Array[Int]): Int =
@@ -280,10 +289,12 @@ object GNDArray:
     val strides = colMajorStrides(shape)
     requireValidLeaf(data, shape, strides, 0)
     GNDLeaf(data, shape.clone(), strides, 0)
+  end apply
 
   def apply(data: Array[Float], shape: Array[Int], strides: Array[Int], offset: Int = 0): GNDLeaf =
     requireValidLeaf(data, shape, strides, offset)
     GNDLeaf(data, shape.clone(), strides.clone(), offset)
+  end apply
 
   /** 1D convenience. */
   def fromArray(data: Array[Float]): GNDLeaf =
@@ -304,24 +315,28 @@ object GNDArray:
       end while
     end if
     s
+  end colMajorStrides
 
   private def requireValidLeaf(data: Array[Float], shape: Array[Int], strides: Array[Int], offset: Int): Unit =
     if shape.length != strides.length then
       throw new IllegalArgumentException(
         s"GNDArray: shape rank ${shape.length} != strides rank ${strides.length}"
       )
+    end if
     if shape.exists(_ < 0) then
       throw new IllegalArgumentException(
         s"GNDArray: shape has negative dimension: [${shape.mkString(",")}]"
       )
-    if offset < 0 then
-      throw new IllegalArgumentException(s"GNDArray: negative offset $offset")
+    end if
+    if offset < 0 then throw new IllegalArgumentException(s"GNDArray: negative offset $offset")
+    end if
     // Check that every reachable index stays within data bounds
     if shape.nonEmpty then
       var maxIdx = offset
       var i = 0
       while i < shape.length do
         if shape(i) > 0 then maxIdx += (shape(i) - 1) * math.abs(strides(i))
+        end if
         i += 1
       end while
       if maxIdx >= data.length then
@@ -329,6 +344,7 @@ object GNDArray:
           s"GNDArray: max reachable index $maxIdx >= data.length ${data.length} " +
             s"(shape=[${shape.mkString(",")}], strides=[${strides.mkString(",")}], offset=$offset)"
         )
+      end if
     end if
   end requireValidLeaf
 
@@ -355,25 +371,25 @@ private[gpu] object GNDExprCompiler:
     transferLog(s"  GPU→CPU done, wrapping $n floats as GNDLeaf shape=[${outShape.mkString(",")}]")
     val strides = GNDArray.colMajorStrides(outShape)
     GNDLeaf(result, outShape, strides, 0)
+  end run
 
   /** Recursively lower a GNDExpr tree to a flat GExpr tree.
     *
-    * Elementwise ops map 1:1. Reshape is a no-op (same flat data).
-    * Broadcast, matmul, and transpose throw — they require non-trivial
-    * GPU kernels that the 1D GExpr path doesn't support yet.
+    * Elementwise ops map 1:1. Reshape is a no-op (same flat data). Broadcast, matmul, and transpose throw — they
+    * require non-trivial GPU kernels that the 1D GExpr path doesn't support yet.
     */
   private def lower(expr: GNDExpr): GExpr =
     expr match
-      case leaf: GNDLeaf                  =>
+      case leaf: GNDLeaf =>
         requireContiguous(leaf)
         transferLog(s"  lower: GNDLeaf(${leaf.data.length} floats, shape=[${leaf.shape.mkString(",")}]) → GLeaf")
         GLeaf(leaf.data)
-      case GNDUnaryOp(input, fn)          => GUnaryOp(lower(input), fn)
-      case GNDScalarOp(input, s, fn)      => GScalarOp(lower(input), s, fn)
-      case GNDClampOp(input, f, c)        => GClampOp(lower(input), f, c)
-      case GNDBinaryOp(left, right, fn)   => GBinaryOp(lower(left), lower(right), fn)
-      case GNDReshapeOp(input, _)         => lower(input) // same flat data
-      case _: GNDBroadcastOp =>
+      case GNDUnaryOp(input, fn)        => GUnaryOp(lower(input), fn)
+      case GNDScalarOp(input, s, fn)    => GScalarOp(lower(input), s, fn)
+      case GNDClampOp(input, f, c)      => GClampOp(lower(input), f, c)
+      case GNDBinaryOp(left, right, fn) => GBinaryOp(lower(left), lower(right), fn)
+      case GNDReshapeOp(input, _)       => lower(input) // same flat data
+      case _: GNDBroadcastOp            =>
         throw new UnsupportedOperationException(
           "GNDExpr broadcast lowering to GExpr is not yet supported"
         )
@@ -392,17 +408,21 @@ private[gpu] object GNDExprCompiler:
       throw new UnsupportedOperationException(
         s"GNDExpr lowering requires offset=0, got ${leaf.offset}"
       )
+    end if
     val expected = GNDArray.colMajorStrides(leaf.shape)
     if !java.util.Arrays.equals(leaf.strides, expected) then
       throw new UnsupportedOperationException(
         s"GNDExpr lowering requires contiguous col-major strides [${expected.mkString(",")}], " +
           s"got [${leaf.strides.mkString(",")}]"
       )
+    end if
     val n = GNDShapeAnalysis.numel(leaf.shape)
     if leaf.data.length != n then
       throw new UnsupportedOperationException(
         s"GNDExpr lowering requires data.length == numel(shape) ($n), got ${leaf.data.length}"
       )
+    end if
+  end requireContiguous
 
   // ── Fused CPU backend ──────────────────────────────────
 
@@ -418,6 +438,7 @@ private[gpu] object GNDExprCompiler:
     end while
     val strides = GNDArray.colMajorStrides(outShape)
     GNDLeaf(out, outShape, strides, 0)
+  end runCpu
 
   /** Recursively evaluate the expression tree for a single flat index. */
   private def evalElement(expr: GNDExpr, i: Int): Float =

--- a/gvecxt/src/GpuVsCpuBench.scala
+++ b/gvecxt/src/GpuVsCpuBench.scala
@@ -1,0 +1,159 @@
+package vecxt.gpu
+
+import vecxt.all.*
+import vecxt.BoundsCheck.DoBoundsCheck.no
+import vecxt.ndarray.NDArray
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+/** Quick GPU vs CPU (unfused) vs CPU (fused) timing benchmark. */
+@main def gpuVsCpuBench(): Unit =
+  VkCyfraRuntime.using:
+    // warm-up: compile shaders, allocate buffers
+    print("Warming up GPU… ")
+    val w = GNDArray.fromArray(Array(1.0f, 2.0f, 3.0f))
+    val _ = ((w + w) * 2.0f).exp.run
+    println("done.")
+
+    // warm-up: fused CPU interpreter
+    print("Warming up fused CPU… ")
+    val _ = ((w + w) * 2.0f).exp.runCpu
+    println("done.")
+
+    // warm-up: JVM JIT + BLAS JNI classloading
+    print("Warming up unfused CPU… ")
+    val cw = NDArray(Array.fill(100)(1.0f), Array(10, 10))
+    val _ = ((cw + cw) * 2.0f).exp
+    println("done.\n")
+
+    // ── Light pipeline: (a + b) * 2 |> exp  (~4 FLOPs/element) ──
+    println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    println("  LIGHT pipeline: (a + b) * 2.0 |> exp")
+    println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+    benchSize(1000, 1000, "light", lightGpu, lightCpu)
+    benchSize(3162, 3162, "light", lightGpu, lightCpu)
+
+    // ── Heavy pipeline: chain of transcendentals (~15 FLOPs/element) ──
+    println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    println("  HEAVY pipeline: sin(exp(a+b)) * cos(a*b) + atan(a/b) |> exp |> sqrt |> log")
+    println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+    benchSize(1000, 1000, "heavy", heavyGpu, heavyCpu)
+    benchSize(3162, 3162, "heavy", heavyGpu, heavyCpu)
+    benchSize(10000, 10000, "heavy", heavyGpu, heavyCpu)
+
+// ── Pipeline definitions (GPU) ─────────────────────────────
+private def lightGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
+  ((a + b) * 2.0f).exp
+
+private def heavyGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
+  val sum  = a + b
+  val prod = a * b
+  val quot = a / b
+  val t1   = sum.exp.sin           // sin(exp(a+b))
+  val t2   = prod.cos              // cos(a*b)
+  val t3   = quot.atan              // atan(a/b)
+  ((t1 * t2) + t3).exp.sqrt.log    // exp(sin·cos + atan) |> sqrt |> log
+
+// ── Pipeline definitions (CPU) ─────────────────────────────
+private def lightCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
+  ((a + b) * 2.0f).exp
+
+private def heavyCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
+  val sum  = a + b
+  val prod = a * b
+  val quot = a / b
+  val t1   = sum.exp.sin           // sin(exp(a+b))
+  val t2   = prod.cos              // cos(a*b)
+  val t3   = quot.atan              // atan(a/b)
+  ((t1 * t2) + t3).exp.sqrt.log
+
+private def benchSize(
+    rows: Int,
+    cols: Int,
+    label: String,
+    gpuPipeline: (GNDExpr, GNDExpr) => GNDExpr,
+    cpuPipeline: (NDArray[Float], NDArray[Float]) => NDArray[Float]
+)(using io.computenode.cyfra.core.CyfraRuntime): Unit =
+  val n = rows * cols
+  val rng = new java.util.Random(42)
+  val dataA = Array.tabulate(n)(_ => rng.nextFloat().max(0.01f)) // avoid /0 for heavy pipeline
+  val dataB = Array.tabulate(n)(_ => rng.nextFloat().max(0.01f))
+
+  println(s"════════════════════════════════════════")
+  println(s"  ${rows}×${cols}  ($n elements)  [$label]")
+  println(s"════════════════════════════════════════")
+
+  val runs = 3
+
+  // ── GPU runs ─────────────────────────────────────────
+  var gpuTotalMs = 0.0
+  var gpuResult: Option[GNDLeaf] = None
+  logGNDExprTransfers = true
+  logGExprTransfers = true
+  for run <- 1 to runs do
+    val ga = GNDArray.matrix(dataA.clone(), rows, cols)
+    val gb = GNDArray.matrix(dataB.clone(), rows, cols)
+    val t0 = System.nanoTime()
+    val r = gpuPipeline(ga, gb).run
+    val t1 = System.nanoTime()
+    val ms = (t1 - t0) / 1e6
+    println(f"  GPU run $run: $ms%.3f ms")
+    gpuTotalMs += ms
+    gpuResult = Some(r)
+    if run == 1 then
+      logGNDExprTransfers = false
+      logGExprTransfers = false
+  end for
+  val gpuMs = gpuTotalMs / runs
+
+  // ── CPU runs (unfused — separate loop per op) ─────────
+  var cpuTotalMs = 0.0
+  var cpuResult: Option[NDArray[Float]] = None
+  for run <- 1 to runs do
+    val cpuA = NDArray(dataA.clone(), Array(rows, cols))
+    val cpuB = NDArray(dataB.clone(), Array(rows, cols))
+    val t2 = System.nanoTime()
+    val r = cpuPipeline(cpuA, cpuB)
+    val t3 = System.nanoTime()
+    val ms = (t3 - t2) / 1e6
+    println(f"  CPU unfused run $run: $ms%.3f ms")
+    cpuTotalMs += ms
+    cpuResult = Some(r)
+  end for
+  val cpuMs = cpuTotalMs / runs
+
+  // ── CPU fused runs (single pass, no intermediates) ───
+  var fusedTotalMs = 0.0
+  var fusedResult: Option[GNDLeaf] = None
+  for run <- 1 to runs do
+    val fa = GNDArray.matrix(dataA.clone(), rows, cols)
+    val fb = GNDArray.matrix(dataB.clone(), rows, cols)
+    val t4 = System.nanoTime()
+    val r = gpuPipeline(fa, fb).runCpu
+    val t5 = System.nanoTime()
+    val ms = (t5 - t4) / 1e6
+    println(f"  CPU fused run $run: $ms%.3f ms")
+    fusedTotalMs += ms
+    fusedResult = Some(r)
+  end for
+  val fusedMs = fusedTotalMs / runs
+
+  // ── Comparison ───────────────────────────────────────
+  var maxDiffGpuCpu = 0.0f
+  var maxDiffGpuFused = 0.0f
+  var i = 0
+  while i < n do
+    val gv = gpuResult.get.data(i)
+    val d1 = math.abs(gv - cpuResult.get.data(i))
+    val d2 = math.abs(gv - fusedResult.get.data(i))
+    if d1 > maxDiffGpuCpu then maxDiffGpuCpu = d1
+    if d2 > maxDiffGpuFused then maxDiffGpuFused = d2
+    i += 1
+  end while
+
+  println(f"  GPU avg ($runs):          $gpuMs%8.3f ms")
+  println(f"  CPU unfused avg ($runs):  $cpuMs%8.3f ms")
+  println(f"  CPU fused avg ($runs):    $fusedMs%8.3f ms")
+  println(f"  max |GPU - CPU unfused|:  $maxDiffGpuCpu%.6f")
+  println(f"  max |GPU - CPU fused|:    $maxDiffGpuFused%.6f")
+  println()
+end benchSize

--- a/gvecxt/src/GpuVsCpuBench.scala
+++ b/gvecxt/src/GpuVsCpuBench.scala
@@ -19,11 +19,23 @@ import io.computenode.cyfra.runtime.VkCyfraRuntime
     val _ = ((w + w) * 2.0f).exp.runCpu
     println("done.")
 
+    // warm-up: fused CPU parallel
+    print("Warming up fused CPU parallel… ")
+    val _ = ((w + w) * 2.0f).exp.runCpuParallel
+    println("done.")
+
     // warm-up: JVM JIT + BLAS JNI classloading
     print("Warming up unfused CPU… ")
     val cw = NDArray(Array.fill(100)(1.0f), Array(10, 10))
     val _ = ((cw + cw) * 2.0f).exp
-    println("done.\n")
+    println("done.")
+
+    // warm-up: unfused CPU parallel (coarse-grained chunk split)
+    print("Warming up unfused CPU parallel… ")
+    val nCores = Runtime.getRuntime.availableProcessors
+    val wArr = Array.fill(100)(1.0f)
+    cpuUnfusedParallel(wArr, wArr, 10, 10, nCores, lightCpu)
+    println(s"done. ($nCores cores)\n")
 
     // ── Light pipeline: (a + b) * 2 |> exp  (~4 FLOPs/element) ──
     println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -68,6 +80,46 @@ private def heavyCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
   ((t1 * t2) + t3).exp.sqrt.log
 end heavyCpu
 
+/** Coarse-grained parallel unfused CPU: split the flat data across [[nThreads]] chunks and run the SIMD-vectorised
+  * [[pipeline]] on each chunk concurrently using a Java parallel IntStream.
+  *
+  * Each chunk is treated as a 1-D NDArray because all ops are elementwise. The per-chunk results are concatenated back
+  * into a single flat array and wrapped in an NDArray with the original shape.
+  */
+private def cpuUnfusedParallel(
+    dataA: Array[Float],
+    dataB: Array[Float],
+    rows: Int,
+    cols: Int,
+    nThreads: Int,
+    pipeline: (NDArray[Float], NDArray[Float]) => NDArray[Float]
+): NDArray[Float] =
+  val n = rows * cols
+  val chunkSize = math.max(1, (n + nThreads - 1) / nThreads)
+  val numChunks = math.min(nThreads, n)
+  val chunkResults = new Array[Array[Float]](numChunks)
+  java.util.stream.IntStream
+    .range(0, numChunks)
+    .parallel()
+    .forEach: (t: Int) =>
+      val start = t * chunkSize
+      val end = math.min(start + chunkSize, n)
+      val len = end - start
+      val chunkA = NDArray(java.util.Arrays.copyOfRange(dataA, start, end), Array(len))
+      val chunkB = NDArray(java.util.Arrays.copyOfRange(dataB, start, end), Array(len))
+      chunkResults(t) = pipeline(chunkA, chunkB).data
+  val out = new Array[Float](n)
+  var offset = 0
+  var t = 0
+  while t < numChunks do
+    val chunk = chunkResults(t)
+    System.arraycopy(chunk, 0, out, offset, chunk.length)
+    offset += chunk.length
+    t += 1
+  end while
+  NDArray(out, Array(rows, cols))
+end cpuUnfusedParallel
+
 private def benchSize(
     rows: Int,
     cols: Int,
@@ -76,12 +128,13 @@ private def benchSize(
     cpuPipeline: (NDArray[Float], NDArray[Float]) => NDArray[Float]
 )(using io.computenode.cyfra.core.CyfraRuntime): Unit =
   val n = rows * cols
+  val nCores = Runtime.getRuntime.availableProcessors
   val rng = new java.util.Random(42)
   val dataA = Array.tabulate(n)(_ => rng.nextFloat().max(0.01f)) // avoid /0 for heavy pipeline
   val dataB = Array.tabulate(n)(_ => rng.nextFloat().max(0.01f))
 
   println(s"════════════════════════════════════════")
-  println(s"  ${rows}×${cols}  ($n elements)  [$label]")
+  println(s"  ${rows}×${cols}  ($n elements)  [$label]  [$nCores cores]")
   println(s"════════════════════════════════════════")
 
   val runs = 3
@@ -108,7 +161,7 @@ private def benchSize(
   end for
   val gpuMs = gpuTotalMs / runs
 
-  // ── CPU runs (unfused — separate loop per op) ─────────
+  // ── CPU runs (unfused — separate SIMD loop per op) ────
   var cpuTotalMs = 0.0
   var cpuResult: Option[NDArray[Float]] = None
   for run <- 1 to runs do
@@ -123,6 +176,20 @@ private def benchSize(
     cpuResult = Some(r)
   end for
   val cpuMs = cpuTotalMs / runs
+
+  // ── CPU runs (unfused parallel — coarse-grained chunk split) ──
+  var cpuParTotalMs = 0.0
+  var cpuParResult: Option[NDArray[Float]] = None
+  for run <- 1 to runs do
+    val t2 = System.nanoTime()
+    val r = cpuUnfusedParallel(dataA.clone(), dataB.clone(), rows, cols, nCores, cpuPipeline)
+    val t3 = System.nanoTime()
+    val ms = (t3 - t2) / 1e6
+    println(f"  CPU unfused ∥ run $run: $ms%.3f ms")
+    cpuParTotalMs += ms
+    cpuParResult = Some(r)
+  end for
+  val cpuParMs = cpuParTotalMs / runs
 
   // ── CPU fused runs (single pass, no intermediates) ───
   var fusedTotalMs = 0.0
@@ -140,25 +207,53 @@ private def benchSize(
   end for
   val fusedMs = fusedTotalMs / runs
 
+  // ── CPU fused parallel (fine-grained: element loop across cores) ──
+  var fusedParTotalMs = 0.0
+  var fusedParResult: Option[GNDLeaf] = None
+  for run <- 1 to runs do
+    val fa = GNDArray.matrix(dataA.clone(), rows, cols)
+    val fb = GNDArray.matrix(dataB.clone(), rows, cols)
+    val t4 = System.nanoTime()
+    val r = gpuPipeline(fa, fb).runCpuParallel
+    val t5 = System.nanoTime()
+    val ms = (t5 - t4) / 1e6
+    println(f"  CPU fused ∥ run $run: $ms%.3f ms")
+    fusedParTotalMs += ms
+    fusedParResult = Some(r)
+  end for
+  val fusedParMs = fusedParTotalMs / runs
+
   // ── Comparison ───────────────────────────────────────
   var maxDiffGpuCpu = 0.0f
   var maxDiffGpuFused = 0.0f
+  var maxDiffGpuCpuPar = 0.0f
+  var maxDiffGpuFusedPar = 0.0f
   var i = 0
   while i < n do
     val gv = gpuResult.get.data(i)
     val d1 = math.abs(gv - cpuResult.get.data(i))
     val d2 = math.abs(gv - fusedResult.get.data(i))
+    val d3 = math.abs(gv - cpuParResult.get.data(i))
+    val d4 = math.abs(gv - fusedParResult.get.data(i))
     if d1 > maxDiffGpuCpu then maxDiffGpuCpu = d1
     end if
     if d2 > maxDiffGpuFused then maxDiffGpuFused = d2
     end if
+    if d3 > maxDiffGpuCpuPar then maxDiffGpuCpuPar = d3
+    end if
+    if d4 > maxDiffGpuFusedPar then maxDiffGpuFusedPar = d4
+    end if
     i += 1
   end while
 
-  println(f"  GPU avg ($runs):          $gpuMs%8.3f ms")
-  println(f"  CPU unfused avg ($runs):  $cpuMs%8.3f ms")
-  println(f"  CPU fused avg ($runs):    $fusedMs%8.3f ms")
-  println(f"  max |GPU - CPU unfused|:  $maxDiffGpuCpu%.6f")
-  println(f"  max |GPU - CPU fused|:    $maxDiffGpuFused%.6f")
+  println(f"  GPU avg ($runs):                 $gpuMs%8.3f ms")
+  println(f"  CPU unfused avg ($runs):         $cpuMs%8.3f ms")
+  println(f"  CPU unfused ∥ avg ($runs):       $cpuParMs%8.3f ms  [$nCores cores, coarse-grained]")
+  println(f"  CPU fused avg ($runs):           $fusedMs%8.3f ms")
+  println(f"  CPU fused ∥ avg ($runs):         $fusedParMs%8.3f ms  [$nCores cores, fine-grained]")
+  println(f"  max |GPU - CPU unfused|:         $maxDiffGpuCpu%.6f")
+  println(f"  max |GPU - CPU unfused ∥|:       $maxDiffGpuCpuPar%.6f")
+  println(f"  max |GPU - CPU fused|:           $maxDiffGpuFused%.6f")
+  println(f"  max |GPU - CPU fused ∥|:         $maxDiffGpuFusedPar%.6f")
   println()
 end benchSize

--- a/gvecxt/src/GpuVsCpuBench.scala
+++ b/gvecxt/src/GpuVsCpuBench.scala
@@ -45,26 +45,28 @@ private def lightGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
   ((a + b) * 2.0f).exp
 
 private def heavyGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
-  val sum  = a + b
+  val sum = a + b
   val prod = a * b
   val quot = a / b
-  val t1   = sum.exp.sin           // sin(exp(a+b))
-  val t2   = prod.cos              // cos(a*b)
-  val t3   = quot.atan              // atan(a/b)
-  ((t1 * t2) + t3).exp.sqrt.log    // exp(sin·cos + atan) |> sqrt |> log
+  val t1 = sum.exp.sin // sin(exp(a+b))
+  val t2 = prod.cos // cos(a*b)
+  val t3 = quot.atan // atan(a/b)
+  ((t1 * t2) + t3).exp.sqrt.log // exp(sin·cos + atan) |> sqrt |> log
+end heavyGpu
 
 // ── Pipeline definitions (CPU) ─────────────────────────────
 private def lightCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
   ((a + b) * 2.0f).exp
 
 private def heavyCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
-  val sum  = a + b
+  val sum = a + b
   val prod = a * b
   val quot = a / b
-  val t1   = sum.exp.sin           // sin(exp(a+b))
-  val t2   = prod.cos              // cos(a*b)
-  val t3   = quot.atan              // atan(a/b)
+  val t1 = sum.exp.sin // sin(exp(a+b))
+  val t2 = prod.cos // cos(a*b)
+  val t3 = quot.atan // atan(a/b)
   ((t1 * t2) + t3).exp.sqrt.log
+end heavyCpu
 
 private def benchSize(
     rows: Int,
@@ -102,6 +104,7 @@ private def benchSize(
     if run == 1 then
       logGNDExprTransfers = false
       logGExprTransfers = false
+    end if
   end for
   val gpuMs = gpuTotalMs / runs
 
@@ -146,7 +149,9 @@ private def benchSize(
     val d1 = math.abs(gv - cpuResult.get.data(i))
     val d2 = math.abs(gv - fusedResult.get.data(i))
     if d1 > maxDiffGpuCpu then maxDiffGpuCpu = d1
+    end if
     if d2 > maxDiffGpuFused then maxDiffGpuFused = d2
+    end if
     i += 1
   end while
 

--- a/gvecxt/test/src/GNDArraySuite.scala
+++ b/gvecxt/test/src/GNDArraySuite.scala
@@ -43,7 +43,9 @@ class GNDArraySuite extends munit.FunSuite:
       GNDArray(Array.ofDim[Float](6), Array(2, 3), Array(1))
 
   test("GNDArray rejects out-of-bounds view"):
-    interceptMessage[IllegalArgumentException]("GNDArray: max reachable index 5 >= data.length 4 (shape=[2,3], strides=[1,2], offset=0)"):
+    interceptMessage[IllegalArgumentException](
+      "GNDArray: max reachable index 5 >= data.length 4 (shape=[2,3], strides=[1,2], offset=0)"
+    ):
       GNDArray(Array.ofDim[Float](4), Array(2, 3), Array(1, 2))
 
   test("GNDArray rejects negative offset"):
@@ -107,24 +109,32 @@ class GNDArraySuite extends munit.FunSuite:
 
   test("validateShape: broadcastTo incompatible [2,3] → [2,4] throws"):
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
-    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: cannot broadcast [2,3] to [2,4] \u2014 incompatible at dimension 1 (3 vs 4)"):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr broadcast: cannot broadcast [2,3] to [2,4] \u2014 incompatible at dimension 1 (3 vs 4)"
+    ):
       a.broadcastTo(Array(2, 4)).validateShape
 
   test("validateShape: broadcastTo more dims in source throws"):
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
-    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: cannot broadcast [2,3] to [6] \u2014 source has more dimensions (2) than target (1)"):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr broadcast: cannot broadcast [2,3] to [6] \u2014 source has more dimensions (2) than target (1)"
+    ):
       a.broadcastTo(Array(6)).validateShape
 
   test("validateShape: binary without broadcast rejects mismatched shapes"):
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
     val b = GNDArray.matrix(Array.ofDim[Float](8), 2, 4)
-    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [2,3] vs [2,4] at dimension 1 (3 vs 4). Use .broadcastTo to align shapes explicitly."):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr binary: shape mismatch \u2014 [2,3] vs [2,4] at dimension 1 (3 vs 4). Use .broadcastTo to align shapes explicitly."
+    ):
       (a + b).validateShape
 
   test("validateShape: binary without broadcast rejects mismatched rank"):
     val a = GNDArray.fromArray(Array.ofDim[Float](3))
     val b = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
-    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [3] vs [2,3] (rank 1 != 2). Use .broadcastTo to align shapes explicitly."):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr binary: shape mismatch \u2014 [3] vs [2,3] (rank 1 != 2). Use .broadcastTo to align shapes explicitly."
+    ):
       (a + b).validateShape
 
   // ── Shape analysis: matmul ───────────────────────────────
@@ -157,7 +167,9 @@ class GNDArraySuite extends munit.FunSuite:
   test("validateShape: matmul inner dim mismatch [2,3] @@ [4,5]"):
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
     val b = GNDArray.matrix(Array.ofDim[Float](20), 4, 5)
-    interceptMessage[IllegalArgumentException]("GNDExpr matmul: inner dimensions don't match \u2014 [2,3] @@ [4,5]: 3 != 4"):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr matmul: inner dimensions don't match \u2014 [2,3] @@ [4,5]: 3 != 4"
+    ):
       (a @@ b).validateShape
 
   test("validateShape: batched matmul [2,3,4] @@ [2,4,5] → [2,3,5]"):
@@ -173,7 +185,9 @@ class GNDArraySuite extends munit.FunSuite:
   test("validateShape: batched matmul batch mismatch [3,2,4] @@ [2,4,5]"):
     val a = GNDArray(Array.ofDim[Float](24), Array(3, 2, 4))
     val b = GNDArray(Array.ofDim[Float](40), Array(2, 4, 5))
-    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: incompatible shapes [3] and [2] at dimension 0 (3 vs 2)"):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr broadcast: incompatible shapes [3] and [2] at dimension 0 (3 vs 2)"
+    ):
       (a @@ b).validateShape
 
   // ── Shape analysis: reshape ──────────────────────────────
@@ -192,7 +206,9 @@ class GNDArraySuite extends munit.FunSuite:
 
   test("validateShape: reshape numel mismatch [2,3] → [2,4]"):
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
-    interceptMessage[IllegalArgumentException]("GNDExpr reshape: cannot reshape [2,3] (6 elements) to [2,4] (8 elements)"):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr reshape: cannot reshape [2,3] (6 elements) to [2,4] (8 elements)"
+    ):
       a.reshape(Array(2, 4)).validateShape
 
   // ── Shape analysis: transpose ────────────────────────────
@@ -238,7 +254,9 @@ class GNDArraySuite extends munit.FunSuite:
     val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
     val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
     val c = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
-    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [2,4] vs [2,3] at dimension 1 (4 vs 3). Use .broadcastTo to align shapes explicitly."):
+    interceptMessage[IllegalArgumentException](
+      "GNDExpr binary: shape mismatch \u2014 [2,4] vs [2,3] at dimension 1 (4 vs 3). Use .broadcastTo to align shapes explicitly."
+    ):
       ((a @@ b).exp + c).validateShape
 
   test("validateShape: deep chain with multiple matmuls"):

--- a/gvecxt/test/src/GNDArraySuite.scala
+++ b/gvecxt/test/src/GNDArraySuite.scala
@@ -1,0 +1,372 @@
+package gvecxt
+
+import vecxt.gpu.*
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+class GNDArraySuite extends munit.FunSuite:
+
+  // ── Construction ─────────────────────────────────────────
+
+  test("GNDArray.fromArray creates 1D leaf"):
+    val leaf = GNDArray.fromArray(Array(1.0f, 2.0f, 3.0f))
+    assertEquals(leaf.shape.toSeq, Seq(1, 2, 3).map(_.toInt).take(0) ++ Seq(3))
+    assertEquals(leaf.shape.toSeq, Seq(3))
+    assertEquals(leaf.strides.toSeq, Seq(1))
+    assertEquals(leaf.offset, 0)
+
+  test("GNDArray.matrix creates 2D col-major leaf"):
+    // 2×3 matrix, col-major: stride = [1, 2]
+    val leaf = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(leaf.shape.toSeq, Seq(2, 3))
+    assertEquals(leaf.strides.toSeq, Seq(1, 2))
+    assertEquals(leaf.offset, 0)
+
+  test("GNDArray 3D col-major strides"):
+    val leaf = GNDArray(Array.ofDim[Float](24), Array(2, 3, 4))
+    assertEquals(leaf.shape.toSeq, Seq(2, 3, 4))
+    assertEquals(leaf.strides.toSeq, Seq(1, 2, 6))
+
+  test("GNDArray custom strides (row-major 2×3)"):
+    // Row-major: stride = [3, 1]
+    val leaf = GNDArray(Array.ofDim[Float](6), Array(2, 3), Array(3, 1))
+    assertEquals(leaf.shape.toSeq, Seq(2, 3))
+    assertEquals(leaf.strides.toSeq, Seq(3, 1))
+
+  test("GNDArray with offset"):
+    // Strided view starting at offset 2
+    val data = Array.ofDim[Float](10)
+    val leaf = GNDArray(data, Array(2, 3), Array(1, 2), offset = 2)
+    assertEquals(leaf.offset, 2)
+
+  test("GNDArray rejects shape/strides rank mismatch"):
+    interceptMessage[IllegalArgumentException]("GNDArray: shape rank 2 != strides rank 1"):
+      GNDArray(Array.ofDim[Float](6), Array(2, 3), Array(1))
+
+  test("GNDArray rejects out-of-bounds view"):
+    interceptMessage[IllegalArgumentException]("GNDArray: max reachable index 5 >= data.length 4 (shape=[2,3], strides=[1,2], offset=0)"):
+      GNDArray(Array.ofDim[Float](4), Array(2, 3), Array(1, 2))
+
+  test("GNDArray rejects negative offset"):
+    interceptMessage[IllegalArgumentException]("GNDArray: negative offset -1"):
+      GNDArray(Array.ofDim[Float](6), Array(2, 3), Array(1, 2), offset = -1)
+
+  test("GNDArray rejects negative dimensions"):
+    interceptMessage[IllegalArgumentException]("GNDArray: shape has negative dimension: [2,-3]"):
+      GNDArray(Array.ofDim[Float](6), Array(2, -3))
+
+  // ── Shape analysis: unary / scalar / clamp ───────────────
+
+  test("validateShape: unary preserves shape"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(a.exp.validateShape.toSeq, Seq(2, 3))
+    assertEquals(a.neg.sin.abs.validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: scalar preserves shape"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals((a + 1.0f).validateShape.toSeq, Seq(2, 3))
+    assertEquals((a * 2.0f).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: clamp preserves shape"):
+    val a = GNDArray(Array.ofDim[Float](24), Array(2, 3, 4))
+    assertEquals(a.clamp(0.0f, 1.0f).validateShape.toSeq, Seq(2, 3, 4))
+
+  test("validateShape: chain preserves shape"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(a.exp.sin.+(3.0f).clamp(0.0f, 10.0f).validateShape.toSeq, Seq(2, 3))
+
+  // ── Shape analysis: explicit broadcasting ────────────────
+
+  test("validateShape: same-shape binary"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals((a + b).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: broadcastTo [1,3] → [2,3] then binary"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](3), 1, 3)
+    assertEquals((a + b.broadcastTo(Array(2, 3))).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: broadcastTo both sides [2,1] + [1,3] → [2,3]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](2), 2, 1)
+    val b = GNDArray.matrix(Array.ofDim[Float](3), 1, 3)
+    val target = Array(2, 3)
+    assertEquals((a.broadcastTo(target) + b.broadcastTo(target)).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: broadcastTo rank extension [3] → [2,3]"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](3))
+    val b = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals((a.broadcastTo(Array(2, 3)) + b).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: broadcastTo [5,1,4] → [5,3,4]"):
+    val a = GNDArray(Array.ofDim[Float](20), Array(5, 1, 4))
+    assertEquals(a.broadcastTo(Array(5, 3, 4)).validateShape.toSeq, Seq(5, 3, 4))
+
+  test("validateShape: broadcastTo [1,3,1] → [5,3,4]"):
+    val b = GNDArray(Array.ofDim[Float](3), Array(1, 3, 1))
+    assertEquals(b.broadcastTo(Array(5, 3, 4)).validateShape.toSeq, Seq(5, 3, 4))
+
+  test("validateShape: broadcastTo incompatible [2,3] → [2,4] throws"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: cannot broadcast [2,3] to [2,4] \u2014 incompatible at dimension 1 (3 vs 4)"):
+      a.broadcastTo(Array(2, 4)).validateShape
+
+  test("validateShape: broadcastTo more dims in source throws"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: cannot broadcast [2,3] to [6] \u2014 source has more dimensions (2) than target (1)"):
+      a.broadcastTo(Array(6)).validateShape
+
+  test("validateShape: binary without broadcast rejects mismatched shapes"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](8), 2, 4)
+    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [2,3] vs [2,4] at dimension 1 (3 vs 4). Use .broadcastTo to align shapes explicitly."):
+      (a + b).validateShape
+
+  test("validateShape: binary without broadcast rejects mismatched rank"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](3))
+    val b = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [3] vs [2,3] (rank 1 != 2). Use .broadcastTo to align shapes explicitly."):
+      (a + b).validateShape
+
+  // ── Shape analysis: matmul ───────────────────────────────
+
+  test("validateShape: matmul 2D×2D [2,3] @@ [3,4] → [2,4]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    assertEquals((a @@ b).validateShape.toSeq, Seq(2, 4))
+
+  test("validateShape: matmul square [3,3] @@ [3,3] → [3,3]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](9), 3, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](9), 3, 3)
+    assertEquals((a @@ b).validateShape.toSeq, Seq(3, 3))
+
+  test("validateShape: matmul vector-matrix [3] @@ [3,4] → [4]"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](3))
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    assertEquals((a @@ b).validateShape.toSeq, Seq(4))
+
+  test("validateShape: matmul matrix-vector [2,3] @@ [3] → [2]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.fromArray(Array.ofDim[Float](3))
+    assertEquals((a @@ b).validateShape.toSeq, Seq(2))
+
+  test("validateShape: matmul dot product [3] @@ [3] → []"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](3))
+    val b = GNDArray.fromArray(Array.ofDim[Float](3))
+    assertEquals((a @@ b).validateShape.toSeq, Seq.empty)
+
+  test("validateShape: matmul inner dim mismatch [2,3] @@ [4,5]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](20), 4, 5)
+    interceptMessage[IllegalArgumentException]("GNDExpr matmul: inner dimensions don't match \u2014 [2,3] @@ [4,5]: 3 != 4"):
+      (a @@ b).validateShape
+
+  test("validateShape: batched matmul [2,3,4] @@ [2,4,5] → [2,3,5]"):
+    val a = GNDArray(Array.ofDim[Float](24), Array(2, 3, 4))
+    val b = GNDArray(Array.ofDim[Float](40), Array(2, 4, 5))
+    assertEquals((a @@ b).validateShape.toSeq, Seq(2, 3, 5))
+
+  test("validateShape: batched matmul with broadcast [1,3,4] @@ [2,4,5] → [2,3,5]"):
+    val a = GNDArray(Array.ofDim[Float](12), Array(1, 3, 4))
+    val b = GNDArray(Array.ofDim[Float](40), Array(2, 4, 5))
+    assertEquals((a @@ b).validateShape.toSeq, Seq(2, 3, 5))
+
+  test("validateShape: batched matmul batch mismatch [3,2,4] @@ [2,4,5]"):
+    val a = GNDArray(Array.ofDim[Float](24), Array(3, 2, 4))
+    val b = GNDArray(Array.ofDim[Float](40), Array(2, 4, 5))
+    interceptMessage[IllegalArgumentException]("GNDExpr broadcast: incompatible shapes [3] and [2] at dimension 0 (3 vs 2)"):
+      (a @@ b).validateShape
+
+  // ── Shape analysis: reshape ──────────────────────────────
+
+  test("validateShape: reshape [2,3] → [3,2]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(a.reshape(Array(3, 2)).validateShape.toSeq, Seq(3, 2))
+
+  test("validateShape: reshape [2,3] → [6]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(a.reshape(Array(6)).validateShape.toSeq, Seq(6))
+
+  test("validateShape: reshape [6] → [2,3]"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](6))
+    assertEquals(a.reshape(Array(2, 3)).validateShape.toSeq, Seq(2, 3))
+
+  test("validateShape: reshape numel mismatch [2,3] → [2,4]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    interceptMessage[IllegalArgumentException]("GNDExpr reshape: cannot reshape [2,3] (6 elements) to [2,4] (8 elements)"):
+      a.reshape(Array(2, 4)).validateShape
+
+  // ── Shape analysis: transpose ────────────────────────────
+
+  test("validateShape: transpose [2,3] → [3,2]"):
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    assertEquals(a.T.validateShape.toSeq, Seq(3, 2))
+
+  test("validateShape: transpose [2,3,4] → [4,3,2]"):
+    val a = GNDArray(Array.ofDim[Float](24), Array(2, 3, 4))
+    assertEquals(a.T.validateShape.toSeq, Seq(4, 3, 2))
+
+  test("validateShape: transpose 1D throws"):
+    val a = GNDArray.fromArray(Array.ofDim[Float](3))
+    interceptMessage[IllegalArgumentException]("GNDExpr transpose requires at least 2 dimensions, got [3]"):
+      a.T.validateShape
+
+  // ── Shape analysis: composite expressions ────────────────
+
+  test("validateShape: (A @@ B).exp + C with explicit broadcast"):
+    // A: [2,3], B: [3,4] → matmul → [2,4]
+    // C: [1,4] → broadcastTo [2,4] → [2,4]
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    val c = GNDArray.matrix(Array.ofDim[Float](4), 1, 4)
+    assertEquals(((a @@ b).exp + c.broadcastTo(Array(2, 4))).validateShape.toSeq, Seq(2, 4))
+
+  test("validateShape: (A.T @@ B) * 2.0"):
+    // A: [3,2] → T → [2,3], B: [3,4] → matmul → [2,4]
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 3, 2)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    assertEquals(((a.T @@ b) * 2.0f).validateShape.toSeq, Seq(2, 4))
+
+  test("validateShape: A.reshape([3,2]) @@ B"):
+    // A: [6], reshape → [3,2], B: [2,4] → matmul → [3,4]
+    val a = GNDArray.fromArray(Array.ofDim[Float](6))
+    val b = GNDArray.matrix(Array.ofDim[Float](8), 2, 4)
+    assertEquals((a.reshape(Array(3, 2)) @@ b).validateShape.toSeq, Seq(3, 4))
+
+  test("validateShape: complex chain catches inner mismatch"):
+    // (A @@ B).exp + C where C is wrong shape — binary requires exact match
+    // A: [2,3], B: [3,4] → [2,4]. C: [2,3] → [2,4] + [2,3] fails
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    val c = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    interceptMessage[IllegalArgumentException]("GNDExpr binary: shape mismatch \u2014 [2,4] vs [2,3] at dimension 1 (4 vs 3). Use .broadcastTo to align shapes explicitly."):
+      ((a @@ b).exp + c).validateShape
+
+  test("validateShape: deep chain with multiple matmuls"):
+    // A: [2,3], B: [3,4], C: [4,5]
+    // (A @@ B) @@ C → [2,4] @@ [4,5] → [2,5]
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    val c = GNDArray.matrix(Array.ofDim[Float](20), 4, 5)
+    assertEquals(((a @@ b) @@ c).validateShape.toSeq, Seq(2, 5))
+
+  // ── GPU dispatch: elementwise run ────────────────────────
+
+  test("run: 1D unary neg"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.fromArray(Array(1.0f, -2.0f, 3.0f))
+      val result = a.neg.run
+      assertEquals(result.data.toSeq, Seq(-1.0f, 2.0f, -3.0f))
+      assertEquals(result.shape.toSeq, Seq(3))
+
+  test("run: 2D scalar add"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f), 2, 3)
+      val result = (a + 10.0f).run
+      assertEquals(result.data.toSeq, Seq(11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f))
+      assertEquals(result.shape.toSeq, Seq(2, 3))
+      assertEquals(result.strides.toSeq, Seq(1, 2)) // col-major
+
+  test("run: 2D binary add same shape"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f), 2, 3)
+      val b = GNDArray.matrix(Array(10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f), 2, 3)
+      val result = (a + b).run
+      assertEquals(result.data.toSeq, Seq(11.0f, 22.0f, 33.0f, 44.0f, 55.0f, 66.0f))
+      assertEquals(result.shape.toSeq, Seq(2, 3))
+
+  test("run: 2D binary sub"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(10.0f, 20.0f, 30.0f, 40.0f), 2, 2)
+      val b = GNDArray.matrix(Array(1.0f, 2.0f, 3.0f, 4.0f), 2, 2)
+      val result = (a - b).run
+      assertEquals(result.data.toSeq, Seq(9.0f, 18.0f, 27.0f, 36.0f))
+
+  test("run: 2D binary mul"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(2.0f, 3.0f, 4.0f, 5.0f), 2, 2)
+      val b = GNDArray.matrix(Array(10.0f, 10.0f, 10.0f, 10.0f), 2, 2)
+      val result = (a * b).run
+      assertEquals(result.data.toSeq, Seq(20.0f, 30.0f, 40.0f, 50.0f))
+
+  test("run: fused chain exp then scalar add on 2D"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(0.0f, 0.0f, 0.0f, 0.0f), 2, 2)
+      val result = (a.exp + 1.0f).run
+      // exp(0) + 1 = 2.0 for every element
+      result.data.foreach: v =>
+        assert(math.abs(v - 2.0f) < 1e-5f, s"expected ~2.0, got $v")
+      assertEquals(result.shape.toSeq, Seq(2, 2))
+
+  test("run: 3D elementwise add"):
+    VkCyfraRuntime.using:
+      val data = Array.tabulate(24)(_.toFloat)
+      val a = GNDArray(data, Array(2, 3, 4))
+      val b = GNDArray(Array.fill(24)(1.0f), Array(2, 3, 4))
+      val result = (a + b).run
+      assertEquals(result.shape.toSeq, Seq(2, 3, 4))
+      val expected = data.map(_ + 1.0f)
+      assertEquals(result.data.toSeq, expected.toSeq)
+
+  test("run: reshape then unary (contiguous passthrough)"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.fromArray(Array(1.0f, 4.0f, 9.0f, 16.0f, 25.0f, 36.0f))
+      val result = a.reshape(Array(2, 3)).sqrt.run
+      assertEquals(result.shape.toSeq, Seq(2, 3))
+      assertEquals(result.data.toSeq, Seq(1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f))
+
+  test("run: clamp on 2D"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array(-5.0f, 0.5f, 3.0f, 10.0f), 2, 2)
+      val result = a.clamp(0.0f, 2.0f).run
+      assertEquals(result.data.toSeq, Seq(0.0f, 0.5f, 2.0f, 2.0f))
+
+  // ── GPU dispatch: error cases ────────────────────────────
+
+  test("run: non-contiguous (row-major) leaf throws"):
+    VkCyfraRuntime.using:
+      val a = GNDArray(Array.ofDim[Float](6), Array(2, 3), Array(3, 1))
+      interceptMessage[UnsupportedOperationException](
+        "GNDExpr lowering requires contiguous col-major strides [1,2], got [3,1]"
+      ):
+        a.neg.run
+
+  test("run: leaf with offset throws"):
+    VkCyfraRuntime.using:
+      val a = GNDArray(Array.ofDim[Float](10), Array(2, 3), Array(1, 2), offset = 2)
+      interceptMessage[UnsupportedOperationException](
+        "GNDExpr lowering requires offset=0, got 2"
+      ):
+        a.neg.run
+
+  test("run: broadcast throws"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array.ofDim[Float](3), 1, 3)
+      interceptMessage[UnsupportedOperationException](
+        "GNDExpr broadcast lowering to GExpr is not yet supported"
+      ):
+        a.broadcastTo(Array(2, 3)).run
+
+  test("run: matmul throws"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+      val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+      interceptMessage[UnsupportedOperationException](
+        "GNDExpr matmul lowering to GExpr is not yet supported"
+      ):
+        (a @@ b).run
+
+  test("run: transpose throws"):
+    VkCyfraRuntime.using:
+      val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+      interceptMessage[UnsupportedOperationException](
+        "GNDExpr transpose lowering to GExpr is not yet supported \u2014 non-contiguous layout"
+      ):
+        a.T.run
+
+  test("validateShape: matmul then transpose"):
+    // A: [2,3], B: [3,4] → [2,4] → T → [4,2]
+    val a = GNDArray.matrix(Array.ofDim[Float](6), 2, 3)
+    val b = GNDArray.matrix(Array.ofDim[Float](12), 3, 4)
+    assertEquals((a @@ b).T.validateShape.toSeq, Seq(4, 2))
+
+end GNDArraySuite

--- a/gvecxt/test/src/GvecxtSuite.scala
+++ b/gvecxt/test/src/GvecxtSuite.scala
@@ -1,0 +1,252 @@
+package gvecxt
+
+import vecxt.gpu.*
+import vecxt.all.{*, given}
+import io.computenode.cyfra.runtime.VkCyfraRuntime
+
+class GvecxtSuite extends munit.FunSuite:
+
+  test("Array[Float].gpu creates a GLeaf"):
+    val data = Array(1.0f, 2.0f, 3.0f)
+    val g = data.gpu
+    assert(g.isInstanceOf[GLeaf])
+    assertEquals(g.asInstanceOf[GLeaf].data.toSeq, data.toSeq)
+
+  test("chaining builds AST without GPU"):
+    val expr = Array(1.0f).gpu.exp.sin.+(3.0f)
+    // Just check it's a GScalarOp wrapping a chain — no CyfraRuntime needed
+    assert(expr.isInstanceOf[GScalarOp])
+
+  test("single unary op: neg"):
+    VkCyfraRuntime.using:
+      val input = Array(1.0f, -2.0f, 3.0f)
+      val result = input.gpu.neg.run
+      assertEquals(result.toSeq, Seq(-1.0f, 2.0f, -3.0f))
+
+  test("single unary op: abs"):
+    VkCyfraRuntime.using:
+      val input = Array(-1.0f, 2.0f, -3.0f)
+      val result = input.gpu.abs.run
+      assertEquals(result.toSeq, Seq(1.0f, 2.0f, 3.0f))
+
+  test("scalar add"):
+    VkCyfraRuntime.using:
+      val input = Array(1.0f, 2.0f, 3.0f)
+      val result = input.gpu.+(10.0f).run
+      assertEquals(result.toSeq, Seq(11.0f, 12.0f, 13.0f))
+
+  test("scalar mul"):
+    VkCyfraRuntime.using:
+      val input = Array(1.0f, 2.0f, 3.0f)
+      val result = input.gpu.*(2.0f).run
+      assertEquals(result.toSeq, Seq(2.0f, 4.0f, 6.0f))
+
+  test("fused chain: exp then scalar add"):
+    VkCyfraRuntime.using:
+      val input = Array(0.0f)
+      val result = input.gpu.exp.+(1.0f).run
+      // exp(0) + 1 = 2.0
+      assertEqualsFloat(result(0), 2.0f, 1e-5f)
+
+  test("fused chain: sin(exp(x)) + 3"):
+    VkCyfraRuntime.using:
+      val input = Array(0.0f, 1.0f)
+      val result = input.gpu.exp.sin.+(3.0f).run
+      // sin(exp(0)) + 3 = sin(1) + 3 ≈ 3.8414709
+      // sin(exp(1)) + 3 = sin(e) + 3 ≈ 3.4107813
+      assertEqualsFloat(result(0), Math.sin(1.0).toFloat + 3.0f, 1e-4f)
+      assertEqualsFloat(result(1), Math.sin(Math.E).toFloat + 3.0f, 1e-4f)
+
+  test("clamp"):
+    VkCyfraRuntime.using:
+      val input = Array(-5.0f, 0.5f, 10.0f)
+      val result = input.gpu.clamp(0.0f, 1.0f).run
+      assertEquals(result.toSeq, Seq(0.0f, 0.5f, 1.0f))
+
+  test("pow via **"):
+    VkCyfraRuntime.using:
+      val input = Array(2.0f, 3.0f)
+      val result = input.gpu.**(2.0f).run
+      assertEqualsFloat(result(0), 4.0f, 1e-5f)
+      assertEqualsFloat(result(1), 9.0f, 1e-4f)
+
+  test("larger array round-trip"):
+    VkCyfraRuntime.using:
+      val n = 1024
+      val input = Array.tabulate(n)(i => i.toFloat)
+      val result = input.gpu.*(2.0f).+(1.0f).run
+      var i = 0
+      while i < n do
+        assertEqualsFloat(result(i), input(i) * 2.0f + 1.0f, 1e-5f)
+        i += 1
+
+  private def assertEqualsFloat(actual: Float, expected: Float, eps: Float)(using munit.Location): Unit =
+    assert(
+      Math.abs(actual - expected) < eps,
+      s"expected $expected but got $actual (diff=${Math.abs(actual - expected)}, eps=$eps)"
+    )
+
+  private def assertArrayEqualsFloat(actual: Array[Float], expected: Array[Float], eps: Float)(using munit.Location): Unit =
+    assertEquals(actual.length, expected.length, s"length mismatch: ${actual.length} vs ${expected.length}")
+    var i = 0
+    while i < actual.length do
+      assertEqualsFloat(actual(i), expected(i), eps)
+      i += 1
+
+  // ── Binary ops: GPU vs vecxt side-by-side ────────────────
+
+  test("binary add: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(1.0f, 2.0f, 3.0f, 4.0f)
+      val b = Array(10.0f, 20.0f, 30.0f, 40.0f)
+
+      val cpuResult = a + b          // vecxt
+      val gpuResult = (a.gpu + b.gpu).run  // gvecxt
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
+
+  test("binary sub: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(10.0f, 20.0f, 30.0f)
+      val b = Array(1.0f, 2.0f, 3.0f)
+
+      val cpuResult = a - b
+      val gpuResult = (a.gpu - b.gpu).run
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
+
+  test("binary mul: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(2.0f, 3.0f, 4.0f)
+      val b = Array(5.0f, 6.0f, 7.0f)
+
+      val cpuResult = a * b
+      val gpuResult = (a.gpu * b.gpu).run
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
+
+  test("binary div: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(10.0f, 20.0f, 30.0f)
+      val b = Array(2.0f, 4.0f, 5.0f)
+
+      val cpuResult = a / b
+      val gpuResult = (a.gpu / b.gpu).run
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
+
+  test("mixed chain: (a.exp + b.sin) * 2.0 — gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(0.0f, 0.5f, 1.0f)
+      val b = Array(1.0f, 1.5f, 2.0f)
+
+      val cpuResult = (a.exp + b.sin) * 2.0f   // vecxt
+      val gpuResult = ((a.gpu.exp + b.gpu.sin) * 2.0f).run
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-3f)
+
+  test("scalar ops: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(1.0f, 2.0f, 3.0f, 4.0f)
+
+      assertArrayEqualsFloat((a.gpu + 10.0f).run, a + 10.0f, 1e-5f)
+      assertArrayEqualsFloat((a.gpu - 1.0f).run, a - 1.0f, 1e-5f)
+      assertArrayEqualsFloat((a.gpu * 3.0f).run, a * 3.0f, 1e-5f)
+      assertArrayEqualsFloat((a.gpu / 2.0f).run, a / 2.0f, 1e-5f)
+
+  test("unary ops: gpu vs vecxt"):
+    VkCyfraRuntime.using:
+      val a = Array(0.1f, 0.5f, 1.0f, 1.5f)
+
+      assertArrayEqualsFloat(a.gpu.exp.run, a.exp, 1e-4f)
+      assertArrayEqualsFloat(a.gpu.sin.run, a.sin, 1e-4f)
+      assertArrayEqualsFloat(a.gpu.cos.run, a.cos, 1e-4f)
+      assertArrayEqualsFloat(a.gpu.sqrt.run, a.sqrt, 1e-4f)
+      assertArrayEqualsFloat(a.gpu.log.run, a.log, 1e-4f)
+      assertArrayEqualsFloat(a.gpu.abs.run, a.abs, 1e-5f)
+      assertArrayEqualsFloat(a.gpu.tan.run, a.tan, 1e-4f)
+
+  test("larger binary: gpu vs vecxt (1024 elements)"):
+    VkCyfraRuntime.using:
+      val n = 1024
+      val a = Array.tabulate(n)(i => (i + 1).toFloat)
+      val b = Array.tabulate(n)(i => (n - i).toFloat)
+
+      val cpuResult = a + b
+      val gpuResult = (a.gpu + b.gpu).run
+
+      assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
+
+  test("dimension mismatch throws"):
+    VkCyfraRuntime.using:
+      val a = Array(1.0f, 2.0f)
+      val b = Array(1.0f, 2.0f, 3.0f)
+      interceptMessage[IllegalArgumentException]("GExpr dimension mismatch: left has 2 elements, right has 3"):
+        (a.gpu + b.gpu).run
+
+  test("validateDimensions catches mismatch eagerly without GPU"):
+    // No CyfraRuntime needed — shape analysis is pure CPU work
+    val a = Array(1.0f, 2.0f)
+    val b = Array(1.0f, 2.0f, 3.0f)
+    interceptMessage[IllegalArgumentException]("GExpr dimension mismatch: left has 2 elements, right has 3"):
+      (a.gpu + b.gpu).validateDimensions
+
+  test("validateDimensions returns correct dimension"):
+    val a = Array(1.0f, 2.0f, 3.0f)
+    val b = Array(4.0f, 5.0f, 6.0f)
+    assertEquals(a.gpu.validateDimensions, 3)
+    assertEquals((a.gpu.exp.sin + 1.0f).validateDimensions, 3)
+    assertEquals(a.gpu.clamp(0.0f, 2.0f).validateDimensions, 3)
+    assertEquals((a.gpu + b.gpu).validateDimensions, 3)
+    assertEquals(((a.gpu.exp + b.gpu.sin) * 2.0f).validateDimensions, 3)
+
+  test("validateDimensions catches deeply nested mismatch"):
+    val a = Array(1.0f, 2.0f)
+    val b = Array(1.0f, 2.0f, 3.0f)
+    // mismatch buried inside: (a.exp + b.sin) * 2.0
+    interceptMessage[IllegalArgumentException]("GExpr dimension mismatch: left has 2 elements, right has 3"):
+      ((a.gpu.exp + b.gpu.sin) * 2.0f).validateDimensions
+
+  test("dimension mismatch caught before any GPU transfer"):
+    VkCyfraRuntime.using:
+      logGExprTransfers = true
+      val logs = new java.io.ByteArrayOutputStream()
+      val oldErr = System.err
+      System.setErr(new java.io.PrintStream(logs))
+      try
+        val a = Array(1.0f, 2.0f)
+        val b = Array(1.0f, 2.0f, 3.0f)
+        interceptMessage[IllegalArgumentException]("GExpr dimension mismatch: left has 2 elements, right has 3"):
+          (a.gpu + b.gpu).run
+        // No transfer logs should have been emitted — error was caught in shape analysis
+        val output = logs.toString
+        assert(!output.contains("CPU→GPU"), s"Expected no GPU transfers but got: $output")
+        assert(!output.contains("GPU→CPU"), s"Expected no GPU transfers but got: $output")
+      finally
+        System.setErr(oldErr)
+        logGExprTransfers = false
+
+  test("transfer log: (a.exp + b.sin) * 2.0"):
+    VkCyfraRuntime.using:
+      logGExprTransfers = true
+      val a = Array(0.0f, 0.5f, 1.0f)
+      val b = Array(1.0f, 1.5f, 2.0f)
+      val _ = ((a.gpu.exp + b.gpu.sin) * 2.0f).run
+      logGExprTransfers = false
+
+  test("transfer log: a + b (simple binary)"):
+    VkCyfraRuntime.using:
+      logGExprTransfers = true
+      val a = Array(1.0f, 2.0f, 3.0f)
+      val b = Array(4.0f, 5.0f, 6.0f)
+      val _ = (a.gpu + b.gpu).run
+      logGExprTransfers = false
+
+  test("transfer log: a.exp (single-input)"):
+    VkCyfraRuntime.using:
+      logGExprTransfers = true
+      val a = Array(1.0f, 2.0f, 3.0f)
+      val _ = a.gpu.exp.run
+      logGExprTransfers = false
+
+end GvecxtSuite

--- a/gvecxt/test/src/GvecxtSuite.scala
+++ b/gvecxt/test/src/GvecxtSuite.scala
@@ -79,6 +79,7 @@ class GvecxtSuite extends munit.FunSuite:
       while i < n do
         assertEqualsFloat(result(i), input(i) * 2.0f + 1.0f, 1e-5f)
         i += 1
+      end while
 
   private def assertEqualsFloat(actual: Float, expected: Float, eps: Float)(using munit.Location): Unit =
     assert(
@@ -86,12 +87,16 @@ class GvecxtSuite extends munit.FunSuite:
       s"expected $expected but got $actual (diff=${Math.abs(actual - expected)}, eps=$eps)"
     )
 
-  private def assertArrayEqualsFloat(actual: Array[Float], expected: Array[Float], eps: Float)(using munit.Location): Unit =
+  private def assertArrayEqualsFloat(actual: Array[Float], expected: Array[Float], eps: Float)(using
+      munit.Location
+  ): Unit =
     assertEquals(actual.length, expected.length, s"length mismatch: ${actual.length} vs ${expected.length}")
     var i = 0
     while i < actual.length do
       assertEqualsFloat(actual(i), expected(i), eps)
       i += 1
+    end while
+  end assertArrayEqualsFloat
 
   // ── Binary ops: GPU vs vecxt side-by-side ────────────────
 
@@ -100,8 +105,8 @@ class GvecxtSuite extends munit.FunSuite:
       val a = Array(1.0f, 2.0f, 3.0f, 4.0f)
       val b = Array(10.0f, 20.0f, 30.0f, 40.0f)
 
-      val cpuResult = a + b          // vecxt
-      val gpuResult = (a.gpu + b.gpu).run  // gvecxt
+      val cpuResult = a + b // vecxt
+      val gpuResult = (a.gpu + b.gpu).run // gvecxt
 
       assertArrayEqualsFloat(gpuResult, cpuResult, 1e-5f)
 
@@ -140,7 +145,7 @@ class GvecxtSuite extends munit.FunSuite:
       val a = Array(0.0f, 0.5f, 1.0f)
       val b = Array(1.0f, 1.5f, 2.0f)
 
-      val cpuResult = (a.exp + b.sin) * 2.0f   // vecxt
+      val cpuResult = (a.exp + b.sin) * 2.0f // vecxt
       val gpuResult = ((a.gpu.exp + b.gpu.sin) * 2.0f).run
 
       assertArrayEqualsFloat(gpuResult, cpuResult, 1e-3f)
@@ -225,6 +230,7 @@ class GvecxtSuite extends munit.FunSuite:
       finally
         System.setErr(oldErr)
         logGExprTransfers = false
+      end try
 
   test("transfer log: (a.exp + b.sin) * 2.0"):
     VkCyfraRuntime.using:

--- a/site/docs/experimental/gpu.md
+++ b/site/docs/experimental/gpu.md
@@ -1,0 +1,120 @@
+# GPU Experiment Results
+
+The `gvecxt` module explores GPU-accelerated elementwise computation via [Cyfra](https://github.com/ComputeNode/cyfra), a Scala DSL that compiles to SPIR-V / Vulkan compute shaders.
+
+This page summarises the findings from the experiment and maps them to the POCs outlined in the [sparta feasibility analysis](../../notes/sparta.md).
+
+## What Was Built
+
+### Expression Tree (`GExpr` / `GNDExpr`)
+
+A lazy, backend-agnostic AST for elementwise float operations:
+
+```scala
+val a = GNDArray.matrix(dataA, 1000, 1000)
+val b = GNDArray.matrix(dataB, 1000, 1000)
+val result = ((a + b) * 2.0f).exp  // builds AST — no work yet
+result.run       // GPU dispatch via Cyfra
+result.runCpu    // fused CPU interpreter (single pass, no intermediates)
+```
+
+Supported AST nodes: unary (`neg`, `abs`, `exp`, `sqrt`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `log`), scalar (`+`, `-`, `*`, `/`, `pow`, `clamp`), elementwise binary (`+`, `-`, `*`, `/`), reshape, broadcast (shape analysis only), matmul (shape analysis only), transpose (shape analysis only).
+
+### Phase 1: Shape Analysis
+
+Walks the AST on the CPU and validates dimensions at every node. No GPU work, no data movement. Catches mismatches eagerly before any allocation.
+
+### Phase 2: Fused Single-Dispatch Compiler
+
+All leaf arrays are packed into one contiguous `GBuffer`. A single `GProgram` kernel fuses the entire expression tree — each GPU thread evaluates the full pipeline for one element using index arithmetic to read from each leaf's region of the packed buffer.
+
+For `(a.exp + b.sin) * 2.0f`:
+- **Before (Phase 0):** 4 GPU dispatches, 5 uploads, 4 downloads
+- **After (Phase 2):** 1 GPU dispatch, 1 upload, 1 download
+
+### Fused CPU Interpreter (`runCpu`)
+
+The same `GNDExpr` tree can be evaluated on the CPU via a per-element recursive interpreter — single pass, no intermediate `Array[Float]` allocations. This isolates fusion effects from hardware effects in benchmarking.
+
+## Benchmark Results
+
+Three backends compared: **GPU** (Cyfra/Vulkan), **CPU unfused** (vecxt `NDArray[Float]` ops — vectorised via Java Vector API but separate loop + allocation per op), **CPU fused** (recursive AST interpreter — single pass but scalar).
+
+**Light pipeline:** `(a + b) * 2.0 |> exp` — ~4 FLOPs/element
+
+| Size | GPU | CPU unfused | CPU fused |
+|------|-----|-------------|-----------|
+| 1M | 28ms | 55ms | **27ms** |
+| 10M | 156ms | **123ms** | 245ms |
+
+**Heavy pipeline:** `sin(exp(a+b)) * cos(a*b) + atan(a/b) |> exp |> sqrt |> log` — ~15 FLOPs/element
+
+| Size | GPU | CPU unfused | CPU fused |
+|------|-----|-------------|-----------|
+| 1M | **13ms** | 174ms | 158ms |
+| 10M | **96ms** | 747ms | 1596ms |
+| 100M | **2.1s** | 8.9s | 16.2s |
+
+### Analysis
+
+1. **GPU dominates compute-heavy pipelines** — 12× faster at 1M, 4× at 100M for the heavy pipeline. The advantage narrows at scale because transfer cost (uploading 200M floats + downloading 100M) grows linearly while compute grows sub-linearly on a fixed GPU.
+
+2. **Kernel fusion matters more than hardware.** The CPU unfused path allocates ~12 temporary arrays for the heavy pipeline (4.8 GB at 100M elements). The GPU's real advantage isn't raw FLOP throughput — it's that the fused kernel eliminates all intermediate allocations and does a single pass over memory.
+
+3. **The fused CPU interpreter is slow at scale** because it does a recursive AST walk per element (~15 virtual dispatches per float). The JVM can't SIMD-vectorise a recursive tree walk, so it loses to the unfused path's tight vectorised loops (Java Vector API) despite avoiding intermediate allocations. The optimal CPU path would be a flat bytecode interpreter or JIT-compiled fused loop.
+
+4. **Transfer overhead is the GPU bottleneck.** The light pipeline (4 FLOPs/element) loses to CPU at 10M because the arithmetic intensity (FLOPs per byte transferred) is too low. GPU wins when there's enough compute to amortise the bus cost.
+
+## Mapping to Sparta POCs
+
+| Sparta POC | Status | Notes |
+|------------|--------|-------|
+| **POC 4: Cyfra Smoke Test** | ✅ Satisfied | Round-trip works: CPU → GPU buffer → compute → CPU. Fused dispatch for arbitrary expression trees with multiple inputs. Acceptable latency for arrays ≥ 1M elements. |
+| **POC 5: MathExpr → Cyfra Pipeline** | ✅ Partially satisfied | The `GNDExpr` AST → Cyfra compiler is exactly this pattern. It walks an expression tree and emits Cyfra DSL calls that build a single SPIR-V pipeline. The "AST-to-pipeline compilation" approach from sparta works and is implemented. |
+| **POC 1: MathTrig[NDArray]** | ⬜ Not addressed | The `GNDExpr` tree is a separate IR from mathlify's `MathExpr`. Bridging them requires implementing `MathTrig[GNDExpr]` instances. The `zero`/`one`/`fromDouble` shape problem identified in sparta remains unresolved. |
+| **POC 2/3: AD (forward/reverse)** | ⬜ Not addressed | No differentiation work done. But the fused GPU pipeline is the execution substrate that AD would target. |
+
+### Key Sparta Risk Assessment Updates
+
+| Risk | Sparta Rating | Updated Rating | Evidence |
+|------|---------------|----------------|----------|
+| Cyfra op coverage / maturity | 🔴 High | 🟡 Medium | Elementwise ops are solid. Reductions, matmul, comparisons missing from AST but Cyfra DSL has the primitives. |
+| Cyfra compile-time DSL vs runtime AST mismatch | 🔴 High | 🟢 Resolved | The packed-buffer `GProgram.static` approach successfully bridges runtime AST structure to compile-time Layout. Single `FusedLayout` handles any number of inputs. |
+| Per-op GPU dispatch overhead | — | 🟢 Resolved | Fused dispatch eliminates this entirely. One kernel for the full expression tree. |
+
+## Missing GPU Kernel Operations for NDArray Parity
+
+The `GNDExpr` AST has shape analysis for broadcast, matmul, and transpose, but lowering to GPU kernels throws `UnsupportedOperationException`. Below is a complete gap analysis.
+
+### Operations with AST Nodes but No Lowering
+
+| Operation | Shape Analysis | GPU Lowering | What's Needed |
+|-----------|---------------|--------------|---------------|
+| **Broadcast** | ✅ Full validation | ❌ Throws | Cyfra kernel with per-dimension stride logic (stride=0 for broadcast dims). Conceptually simple but requires non-trivial index arithmetic. |
+| **MatMul** (`@@`) | ✅ Full shape rules (batched, 1D, 2D) | ❌ Throws | Tiled matmul kernel via `GProgram`. Cyfra has the primitives (`GBuffer.read`, shared memory via `GSeq`) but no built-in GEMM. This is the hardest single operation to implement efficiently. |
+| **Transpose** (`.T`) | ✅ Shape reversal | ❌ Throws | For the fused elementwise path: just swap stride order in index arithmetic. For materialised output: needs a copy kernel with stride-aware indexing. |
+
+### Operations Completely Absent from the AST
+
+| Category | Operations | Cyfra Support | Effort |
+|----------|-----------|---------------|--------|
+| **Reductions** | `sum`, `max`, `min`, `mean`, `argmax`, `argmin` (global + per-axis) | `GSeq.fold` / multi-stage `GExecution` pipeline | Medium-High. Parallel reduction requires multi-stage kernels (local reduce → global reduce). Cyfra's `GExecution` pipeline keeps intermediates on-GPU between stages. |
+| **Comparisons** | `>`, `<`, `>=`, `<=`, `===`, `!==` → boolean array | Cyfra has `GBoolean` + comparison ops | Low. Add AST nodes + lowering — Cyfra directly supports this. |
+| **Conditional/Select** | `where(cond, x, y)` | Cyfra has `when(...).otherwise(...)` | Low. Straightforward to add alongside comparisons. |
+| **Scatter/Gather** | `arr[indices]`, boolean masking | `GBuffer.read(idx)` / `.write(idx, val)` | Medium. Gather is easy (index indirection). Scatter has race conditions requiring atomics. |
+| **Elementwise binary min/max** | `min(a, b)`, `max(a, b)` | `F.min`, `F.max` available | Trivial. Just add a `BinaryFn` enum variant. |
+| **Additional math** | `atan2`, `mod`, `mix`/lerp, `smoothstep` | All available in Cyfra | Low. Add enum variants and lowering cases. |
+| **Type support** | `Int32`, `Float64`, `Boolean` arrays | Cyfra supports all | Medium. Current AST is `Float`-only. Would need type-parameterisation or separate ASTs. |
+
+### Priority Order for Implementation
+
+1. **Comparisons + conditional select** — unblocks boolean masking, `where`, and activation functions like ReLU (`where(x > 0, x, 0)`)
+2. **Broadcast lowering** — required for any real neural network (bias addition, scalar operations on batched data)
+3. **Reductions** — `sum` is critical for loss functions, `mean` for normalisation
+4. **Transpose lowering** — needed for matmul VJP rules (`∂L/∂A = adj @@ Bᵀ`)
+5. **MatMul** — the big one. Essential for any practical neural network but also the most complex GPU kernel to write correctly and performantly
+6. **Scatter/gather** — needed for embedding layers, advanced indexing
+
+### What Cyfra Itself Would Need
+
+Cyfra's DSL already provides the building blocks for everything above. The gaps are in the `GExpr`/`GNDExpr` AST and lowering code, not in Cyfra's capabilities. The one area where Cyfra might need upstream work is **shared memory / workgroup-level operations** for efficient tiled matmul and parallel reductions — this depends on how much of Vulkan's compute model `GProgram` currently exposes.

--- a/site/notes/gpu-roundtrips.md
+++ b/site/notes/gpu-roundtrips.md
@@ -1,0 +1,161 @@
+# GExpr CPU↔GPU Round-Trip Analysis
+
+## Status Quo
+
+Every `GExpr.run` call walks the AST and dispatches GPU work.
+The compiler has two paths:
+
+| Path | When | Transfers |
+|------|------|-----------|
+| **Single-input** (`runSingleInput`) | All nodes trace back to one `GLeaf` | 1 upload + 1 download |
+| **Multi-input** (`materialise`) | Multiple distinct `GLeaf`s in tree | **recursive** — see below |
+
+### Single-input: Good
+
+`a.gpu.exp.sin.+(3.0f).run` fuses into **one** `GFunction` kernel.
+One CPU→GPU upload, one GPU→CPU download. No intermediate round-trips.
+This is the ideal case.
+
+### Multi-input: Bad
+
+Every `GBinaryOp` node forces both children to **materialise to `Array[Float]` on CPU**,
+then re-uploads them for the binary operation. Each `BinaryOp` is a separate `GProgram`.
+
+Unary/scalar nodes wrapping binary sub-trees (`materialiseWrapped`) also force
+an additional GPU dispatch: materialise inner → CPU → new GLeaf → upload → GPU → CPU.
+
+## Concrete Example: `(a.exp + b.sin) * 2.0f`
+
+AST:
+```
+ScalarOp(Mul, 2.0)
+  └─ BinaryOp(Add)
+       ├─ UnaryOp(Exp)
+       │    └─ GLeaf(a)
+       └─ UnaryOp(Sin)
+            └─ GLeaf(b)
+```
+
+Transfer log (from test with `logGExprTransfers = true`, n=3 floats):
+
+```
+[GExpr] run: 2 leaf(s), expr=Scalar(Mul, 2.0)
+[GExpr]   materialiseWrapped: multi-leaf under Scalar(Mul, 2.0) — forcing inner materialise + re-upload
+[GExpr]   materialise BinaryOp(Add) — will materialise both sides to CPU then re-upload
+[GExpr]   CPU→GPU upload 3 floats (runSingleInput)          ← a for exp
+[GExpr]   GPU→CPU download 3 floats (runSingleInput)        ← exp(a) back to CPU
+[GExpr]   CPU→GPU upload 3 floats (runSingleInput)          ← b for sin
+[GExpr]   GPU→CPU download 3 floats (runSingleInput)        ← sin(b) back to CPU
+[GExpr]   CPU→GPU upload 2×3 floats (runBinary Add)         ← exp(a) + sin(b) re-uploaded
+[GExpr]   GPU→CPU download 3 floats (runBinary Add)         ← result back to CPU
+[GExpr]   CPU→GPU upload 3 floats (runSingleInput)          ← result re-uploaded for *2.0
+[GExpr]   GPU→CPU download 3 floats (runSingleInput)        ← final result
+```
+
+**Summary: 4 GPU dispatches, 5 uploads (11 floats up), 4 downloads (12 floats down).**
+
+The ideal: 1 dispatch, 1 upload of `a` and `b` (6 floats), 1 download (3 floats).
+
+## Where Exactly the Round-Trips Happen
+
+| Location | What crosses the bus | Why |
+|----------|---------------------|-----|
+| `runSingleInput` → `gf.run(leaf.data)` | CPU→GPU (leaf data) + GPU→CPU (result) | `GFunction.run` uploads input, downloads result. Fine for leaf chains. |
+| `materialise(BinaryOp)` → recursive `materialise(left)` / `materialise(right)` | Forces each side to `Array[Float]` on CPU | `runBinary` needs `Array[Float]` inputs — that's the problem. |
+| `runBinary` → `GBufferRegion.runUnsafe` | CPU→GPU (both operands) + GPU→CPU (result) | The `BinLayout` uploads both sides as `GBuffer`, reads result back. |
+| `materialiseWrapped` → wraps in new `GLeaf` | Intermediate GPU→CPU then CPU→GPU | Inner result downloaded to CPU, wrapped as `GLeaf`, re-uploaded in outer op. |
+
+**Root cause**: `materialise` returns `Array[Float]` (CPU memory). Every sub-tree must be
+fully evaluated to CPU before it can participate in a parent operation.
+
+## Can We Eliminate `dimCheck` and Stay on GPU?
+
+**No** — `dimCheck` is not the bottleneck, and removing it alone doesn't help.
+
+The issue isn't the dimension check (which is `O(1)` — just comparing two ints).
+The issue is the **intermediate representation**: `materialise` returns `Array[Float]`,
+which forces every sub-expression to fully round-trip through CPU memory.
+
+Even without `dimCheck`, `runBinary` still takes `Array[Float]` arguments.
+
+## The Fix: Two-Phase Compile
+
+### Phase 1: Shape Analysis (CPU only, no data movement)
+
+Walk the AST and compute dimensions at each node. All our ops are elementwise,
+so the rules are trivial:
+
+- `GLeaf(data)` → `data.length`
+- `GUnaryOp(input, _)` → same as input
+- `GScalarOp(input, _, _)` → same as input
+- `GClampOp(input, _, _)` → same as input
+- `GBinaryOp(left, right, _)` → assert `dim(left) == dim(right)`, return it
+
+This is `O(nodes)`, touches no GPU, and catches all dimension errors eagerly.
+
+### Phase 2: Compile Entire AST → Single `GProgram` (one upload, one download)
+
+Once shapes are validated, collect all unique `GLeaf` nodes. These become `GBuffer`
+entries in a single `Layout`. Then walk the AST and emit Cyfra DSL code that reads
+from the appropriate buffer at `GIO.invocationId`.
+
+For `(a.exp + b.sin) * 2.0f`, the compiled program would be conceptually:
+
+```scala
+case class FusedLayout(
+  in0: GBuffer[Float32],   // a
+  in1: GBuffer[Float32],   // b
+  out: GBuffer[Float32]
+) derives Layout
+
+val program = GProgram.static[GFunctionParams, FusedLayout](...): layout =>
+  val idx = GIO.invocationId
+  val v0 = F.exp(layout.in0.read(idx))    // exp(a[i])
+  val v1 = F.sin(layout.in1.read(idx))    // sin(b[i])
+  val v2 = (v0 + v1) * 2.0f              // (exp(a[i]) + sin(b[i])) * 2
+  for _ <- layout.out.write(idx, v2)
+  yield GStruct.Empty()
+```
+
+**Result: 1 GPU dispatch, 2 uploads (a, b), 1 download (result). Zero intermediate round-trips.**
+
+For deeper trees with many binary ops like `((a + b) * (c - d)).exp`,
+the same approach works — all 4 leaves become buffers in one layout,
+one kernel computes the full expression per element.
+
+### Cyfra's `GExecution` for Multi-Stage Pipelines
+
+If we ever need non-elementwise operations (reductions, scans, etc.) that require
+multiple kernel stages, Cyfra's `GExecution` composes `GProgram`s into a pipeline
+where intermediate buffers **stay on GPU** — no CPU round-trip between stages.
+This is documented in `gvecxt/cyfra docs/gpu-pipelines.md`.
+
+## Implementation Sketch
+
+```
+Phase 1                              Phase 2
+───────                              ───────
+walk AST                             collect distinct GLeaf → index map
+  → compute dim(node) for each       generate case class with N GBuffers + 1 out
+  → validate BinaryOp dims match     walk AST, emit Cyfra DSL per node
+  → early error if mismatch          GProgram.static[Params, Layout](...)
+  (zero GPU work)                    GBufferRegion.allocate → runUnsafe
+                                       upload leaves once, download result once
+```
+
+### Challenge: Dynamic Layout
+
+Cyfra's `Layout` is derived at compile time via a `derives Layout` macro.
+For a fixed number of inputs (1, 2, 3, …) we'd need pre-defined layout case classes:
+
+```scala
+case class Layout1(in0: GBuffer[Float32], out: GBuffer[Float32]) derives Layout
+case class Layout2(in0: GBuffer[Float32], in1: GBuffer[Float32], out: GBuffer[Float32]) derives Layout
+case class Layout3(...) derives Layout
+// etc.
+```
+
+Alternatively, since all our ops are elementwise on `Float32`, we might be able to
+pack multiple inputs into one `GBuffer` (interleaved or offset regions) and use
+index arithmetic to address them. This would allow a single Layout definition to
+handle any number of inputs. Worth investigating.

--- a/site/notes/gpu.md
+++ b/site/notes/gpu.md
@@ -15,7 +15,6 @@ val a = GNDArray.matrix(dataA, 1000, 1000)
 val b = GNDArray.matrix(dataB, 1000, 1000)
 val result = ((a + b) * 2.0f).exp  // builds AST — no work yet
 result.run       // GPU dispatch via Cyfra
-result.runCpu    // fused CPU interpreter (single pass, no intermediates)
 ```
 
 Supported AST nodes: unary (`neg`, `abs`, `exp`, `sqrt`, `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `log`), scalar (`+`, `-`, `*`, `/`, `pow`, `clamp`), elementwise binary (`+`, `-`, `*`, `/`), reshape, broadcast (shape analysis only), matmul (shape analysis only), transpose (shape analysis only).

--- a/site/notes/sparta.md
+++ b/site/notes/sparta.md
@@ -1,0 +1,133 @@
+
+
+# Feasibility Analysis & Design Strategy for GPU-Accelerated Backprop in vecxt
+
+This is a genuinely ambitious but plausible plan. Let me research the current state of the codebase and the external dependencies before giving you a detailed assessment.Now I have a thorough understanding of all the pieces. Let me compose a comprehensive analysis.
+
+---
+
+This is a really ambitious and well-thought-out plan. You have strong foundations: `NDArray[A]` with strides/views, mathlify's typeclass-driven `MathExpr[A]` evaluator, and working forward/reverse AD over `Jet[Double]` scalars. Let me break down feasibility, pitfalls, and recommended POC ordering.
+
+## Feasibility Assessment: Mostly Credible, with Sharp Edges
+
+### ✅ Step 1: Forward-prop with `Jet[NDArray[Float]]` — **High confidence**
+
+You already have `MathTrig[Jet[Double]]` working in mathlify's `ForwardDiff.scala`. The pattern is clear: provide `given MathTrig[Jet[NDArray[Float]]]` where:
+
+- `Jet.real: NDArray[Float]` — the primal value
+- `Jet.infinitesimal: Array[NDArray[Float]]` — one NDArray per input dimension (Jacobian columns)
+
+**Key concern:** Spire's `Jet` stores infinitesimals as `Array[T]`. For `T = NDArray[Float]`, each "infinitesimal dimension" is an entire NDArray. For `n` input parameters, the memory is `O(n × numel)` per intermediate result. This is fine for small networks but will blow up for real models with thousands of parameters. Forward-mode AD has `O(n)` cost per output, where `n` = number of inputs. This is inherently the wrong mode for backprop (which needs `O(m)` where `m` = number of outputs, typically 1 for a loss function). **But as a correctness oracle, it's perfect.**
+
+**Pitfall:** Spire's `Jet` hardcodes `Array[T]` for infinitesimals and relies on `ClassTag[T]`. `NDArray[Float]` has a `ClassTag`, so this should work, but you'll want to verify that Spire's generic operations (`+`, `*`, `sin`, etc.) on `Jet` dispatch correctly when `T` is not a scalar. The `MathTrig` instance you write manually will bypass Spire's internal dispatch, so this is actually safer than it sounds.
+
+### ✅ Step 2: Validation via `NDArray[Jet[Double]]` — **Clever but slow**
+
+The idea: element-wise operations on `NDArray[Jet[Double]]` should produce the same numerical results as `Jet[NDArray[Double]]`, just much slower (because each element carries its own derivative tape instead of vectorizing).
+
+**This is a great correctness check.** The existing vecxt `NDArray[A]` is generic, so `NDArray[Jet[Double]]` just works if you can provide the necessary operations. However:
+
+**Pitfall:** vecxt's element-wise ops (`+`, `-`, `exp`, `sin`, etc.) are defined as `extension (a: NDArray[Double])` — they're **concrete on `Double`**, not generic on `A`. You'd need either:
+- New generic extension methods `extension [A: MathTrig](a: NDArray[A])` for arithmetic, or
+- A separate slow-path implementation for `NDArray[Jet[Double]]`
+
+This is probably the first thing to prototype to understand how much of NDArray's API you can actually make generic.
+
+### ⚠️ Step 3: Backprop with `Tej[NDArray[Float]]` — **This is where the dragons are**
+
+Your mathlify `ReverseDiff.scala` already builds a tape and propagates adjoints — but it's hardcoded to `Double` scalars. Lifting this to `NDArray[Float]` means:
+
+1. **The tape nodes store `NDArray[Float]` values** instead of `Double`
+2. **Adjoint propagation operates on NDArrays** — e.g., for `MulOp`, the adjoint rule `∂(a×b)/∂a = b` becomes element-wise multiplication of NDArrays (or matmul for matrix multiply nodes)
+3. **You need VJP (vector-Jacobian product) rules for every operation** — this is the hard part
+
+**Critical design decisions:**
+
+| Operation | Forward | VJP (reverse) |
+|-----------|---------|---------------|
+| `a + b` (elementwise) | trivial | `∂L/∂a += adj`, `∂L/∂b += adj` |
+| `a * b` (elementwise) | trivial | `∂L/∂a += adj * b`, `∂L/∂b += adj * a` |
+| `a @@ b` (matmul) | BLAS dgemm | `∂L/∂a += adj @@ bᵀ`, `∂L/∂b += aᵀ @@ adj` |
+| `broadcastTo(shape)` | zero-copy view | **sum-reduce** along broadcast dims |
+| `exp(a)` | elementwise | `∂L/∂a += adj * exp(a)` |
+| `sum(a)` | reduction | `∂L/∂a += broadcast(adj)` |
+| `reshape(a)` | view | `reshape(adj, original_shape)` |
+
+**Pitfall: broadcast reduction.** Your design doc correctly notes that explicit broadcasting makes the VJP clean (sum-reduce). But the implementation requires tracking which dimensions were broadcast, which means your tape nodes need shape metadata. This is where `MathExpr[A]` as the graph representation gets strained — the AST doesn't naturally carry shape information.
+
+**Pitfall: matmul VJP.** This is the single most performance-critical operation and requires that your NDArray transpose produces views (which it does — good), and that matmul handles transposed inputs efficiently (which requires BLAS `dgemm` with `transA`/`transB` flags — your JVM code already does this).
+
+### ⚠️ Step 4: GPU via Cyfra — **Highest risk, needs early investigation**
+
+Cyfra compiles a Scala DSL to SPIR-V for Vulkan GPUs. The integration model would be:
+
+```
+MathTrig[CyfraArray[Float]]  →  builds SPIR-V compute pipeline  →  GPU execution
+```
+
+**Fundamental tension:** Cyfra is a *compile-time* DSL — it captures Scala expressions and compiles them to GPU shaders. Your evaluator is a *runtime* interpreter walking an AST. These are different paradigms:
+
+| | vecxt (CPU) | Cyfra (GPU) |
+|---|---|---|
+| **Dispatch** | Runtime (pattern match on AST) | Compile-time (DSL → SPIR-V) |
+| **Memory** | JVM heap arrays | GPU device buffers |
+| **Operations** | Immediate execution | Deferred/staged computation |
+
+**This means you probably can't just swap `MathTrig[NDArray[Float]]` for `MathTrig[CyfraArray[Float]]`** and have it work. You'd need either:
+
+1. **Cyfra-side interpreter**: Write a GPU kernel that interprets your AST (like a GPU-side `eval`). Possible but defeats the purpose — you'd be interpreting on the GPU.
+2. **AST-to-Cyfra compiler**: Walk your `MathExpr` AST and emit Cyfra DSL calls that build a SPIR-V pipeline. This is more like a JIT compiler. Most promising but substantial work.
+3. **Hybrid**: Keep the AST interpreter on CPU but have `MathTrig` operations that dispatch individual ops to Cyfra GPU kernels. Each `exp`, `matmul`, etc. is a separate GPU dispatch. **This is the easiest starting point** but will be slow for small arrays due to CPU↔GPU transfer overhead.
+
+**Pitfall:** Cyfra is in beta, JVM-only (Vulkan bindings), and its operation surface may not cover everything you need (matmul? reductions along axes? broadcast?). You need to verify this early.
+
+## Recommended POC Order
+
+### POC 1: `MathTrig[NDArray[Double]]` (1-2 weeks)
+**Goal:** Prove the typeclass evaluator works with tensor-valued expressions.
+
+```scala
+given MathTrig[NDArray[Double]] with
+  def zero = NDArray.zeros[Double](???) // ← problem: what shape?
+  def plus(a: NDArray[Double], b: NDArray[Double]) = a + b
+  def exp(a: NDArray[Double]) = a.exp
+  // ...
+```
+
+**Immediate pitfall you'll hit:** `MathTrig` requires `zero`, `one`, `fromLong`, `fromDouble` — these are shape-agnostic scalars. For NDArrays, `zero` depends on shape. You'll need either:
+- A shape-aware factory (smuggled in via closure/context)
+- Scalar broadcasting (`fromDouble(3.0)` produces a 0-D or 1-element NDArray that broadcasts)
+
+**This is the single most important design question to resolve first.** If `MathTrig[NDArray[_]]` can't cleanly handle `zero`/`one`/`fromDouble`, the entire typeclass-evaluator approach needs rethinking.
+
+### POC 2: Forward-mode `Jet[NDArray[Double]]` (1 week after POC 1)
+Implement `MathTrig[Jet[NDArray[Double]]]` using your POC 1 instance. Validate against `NDArray[Jet[Double]]` for a small expression like `x^2 + sin(y)` where `x` and `y` are 2×2 matrices.
+
+### POC 3: Tape-based reverse mode on NDArrays (2-3 weeks)
+Port `ReverseDiff` to work with `NDArray[Double]`. Start with elementwise ops only (no matmul, no broadcasting). Validate against POC 2.
+
+### POC 4: Cyfra smoke test (1 week, can run in parallel)
+**Before any integration work:** Write a standalone test that:
+1. Creates two `NDArray[Float]` on the CPU
+2. Transfers them to Cyfra GPU buffers
+3. Does elementwise `a + b` and `a * b` on GPU
+4. Reads back results and compares to CPU
+
+If this round-trip works with acceptable latency for arrays ≥ 10K elements, GPU integration is feasible. If not, you'll know early.
+
+### POC 5: MathExpr → Cyfra pipeline (if POC 4 succeeds)
+Start with the hybrid approach: `MathTrig[CyfraBuffer[Float]]` where each operation dispatches to a GPU kernel. Measure overhead. If per-op dispatch is too slow, explore AST-to-pipeline compilation.
+
+## Summary of Risk Ranking
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `MathTrig.zero`/`one` for shape-dependent types | **🔴 High** | POC 1 — resolve before anything else |
+| NDArray ops are `Double`-only, not generic | **🟡 Medium** | Need generic `extension [A: MathTrig]` path |
+| Forward-mode memory blowup for real models | **🟢 Low** | Expected — forward mode is just for validation |
+| Reverse-mode broadcast VJP complexity | **🟡 Medium** | Start without broadcasting; add later |
+| `MathExpr` AST doesn't carry shape metadata | **🟡 Medium** | May need shape-annotated wrapper or separate graph type |
+| Cyfra op coverage / maturity | **🔴 High** | POC 4 — test early and independently |
+| Cyfra compile-time DSL vs runtime AST mismatch | **🔴 High** | POC 5 — may require AST→Cyfra compiler |
+
+The most likely showstopper is the `MathTrig.zero`/`fromDouble` problem for shaped types. If you solve that cleanly (probably via a shape-carrying context parameter alongside `MathTrig`), the rest is engineering. The Cyfra integration is the wildcard — investigate it in parallel with the AD work so you know whether to design toward it or around it.

--- a/vecxt/src/ndarrayFloatOps.scala
+++ b/vecxt/src/ndarrayFloatOps.scala
@@ -328,6 +328,24 @@ object NDArrayFloatOps:
       if a.isContiguous then mkNDArray(vecxt.floatarrays.sqrt(a.data), a.shape.clone(), a.strides.clone(), 0)
       else unaryOpGeneral(a, x => Math.sqrt(x.toDouble).toFloat)
 
+    /** Element-wise sine. */
+    @targetName("ndFloatSin")
+    inline def sin: NDArray[Float] =
+      if a.isContiguous then mkNDArray(vecxt.floatarrays.sin(a.data), a.shape.clone(), a.strides.clone(), 0)
+      else unaryOpGeneral(a, x => Math.sin(x.toDouble).toFloat)
+
+    /** Element-wise cosine. */
+    @targetName("ndFloatCos")
+    inline def cos: NDArray[Float] =
+      if a.isContiguous then mkNDArray(vecxt.floatarrays.cos(a.data), a.shape.clone(), a.strides.clone(), 0)
+      else unaryOpGeneral(a, x => Math.cos(x.toDouble).toFloat)
+
+    /** Element-wise arctangent. */
+    @targetName("ndFloatAtan")
+    inline def atan: NDArray[Float] =
+      if a.isContiguous then mkNDArray(vecxt.floatarrays.atan(a.data), a.shape.clone(), a.strides.clone(), 0)
+      else unaryOpGeneral(a, x => Math.atan(x.toDouble).toFloat)
+
     /** Element-wise hyperbolic tangent. */
     @targetName("ndFloatTanh")
     inline def tanh: NDArray[Float] =


### PR DESCRIPTION
Full write up in site/notes/gpu.md

Here are some results locally; 

Completed: *Run 3-column benchmark* (3/3)

Fascinating results! The fused CPU interpreter is actually **slower** than the unfused vectorised path at larger sizes:

| Pipeline | Size | GPU | CPU unfused | CPU fused |
|----------|------|-----|-------------|-----------|
| Light | 1M | 28ms | 55ms | **27ms** |
| Light | 10M | 156ms | **123ms** | 245ms |
| Heavy | 1M | **13ms** | 174ms | 158ms |
| Heavy | 10M | **96ms** | 747ms | 1596ms |
| Heavy | 100M | **2.1s** | 8.9s | 16.2s |

We're seeing three regimes:
1. **GPU fused kernel**: fastest for compute-heavy work at all sizes — true SIMD over (potentially thousands of cores, maybe 32 on my Mac mini :-), single pass.
2. **CPU unfused + SIMD**: medium — each op is a tight vectorised loop (Java Vector API), but pays for intermediate allocations and multiple passes
3. **CPU fused interpreter**: worst at scale — single pass but scalar, can't vectorise the recursive tree walk

// ── Pipeline definitions (CPU) ─────────────────────────────
```
// ── Pipeline definitions (GPU) ─────────────────────────────
private def lightGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
  ((a + b) * 2.0f).exp

private def heavyGpu(a: GNDExpr, b: GNDExpr): GNDExpr =
  val sum  = a + b
  val prod = a * b
  val quot = a / b
  val t1   = sum.exp.sin           // sin(exp(a+b))
  val t2   = prod.cos              // cos(a*b)
  val t3   = quot.atan              // atan(a/b)
  ((t1 * t2) + t3).exp.sqrt.log    // exp(sin·cos + atan) |> sqrt |> log

// ── Pipeline definitions (CPU) ─────────────────────────────
private def lightCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
  ((a + b) * 2.0f).exp

private def heavyCpu(a: NDArray[Float], b: NDArray[Float]): NDArray[Float] =
  val sum  = a + b
  val prod = a * b
  val quot = a / b
  val t1   = sum.exp.sin           // sin(exp(a+b))
  val t2   = prod.cos              // cos(a*b)
  val t3   = quot.atan              // atan(a/b)
  ((t1 * t2) + t3).exp.sqrt.log
```


The fused CPU interpreter wins at small sizes (1M light) where avoiding allocations matters, but at scale it's **2× slower than unfused**. The reason: `evalElement` does a **recursive AST walk per element** — that's ~15 virtual dispatches and call frames for every single float in the heavy pipeline. The JVM can't SIMD-vectorise a recursive tree walk, so you're paying per-element function call overhead instead of getting the vectorised `Array[Float].exp` loops that Java's Vector API accelerates. The ideal CPU path would be: fuse the AST into a **flat bytecode** that a tight `while` loop interprets without recursion, then the JVM could vectorise it. But that's a much bigger project.